### PR TITLE
CRISTAL-178: Integrate tiptap

### DIFF
--- a/editors/tiptap/src/vue/c-edit-tiptap.vue
+++ b/editors/tiptap/src/vue/c-edit-tiptap.vue
@@ -174,6 +174,12 @@ onUpdated(() => loadEditor(currentPage.value!));
   background: var(--cr-color-neutral-100);
 }
 
+:deep(.ProseMirror) {
+  outline: none;
+  max-width: var(--cr-sizes-max-page-width);
+  width: 100%;
+}
+
 /*
 TODO: should be moved to a css specific to the empty line placeholder plugin.
  */

--- a/editors/tiptap/src/vue/c-tiptap-bubble-menu.vue
+++ b/editors/tiptap/src/vue/c-tiptap-bubble-menu.vue
@@ -68,6 +68,7 @@ const hideOnEsc = {
 <style scoped>
 .items {
   position: relative;
+  display: flex;
   border-radius: var(--cr-tooltip-border-radius);
   background: white; /* TODO: define a global variable for background color */
   overflow: hidden;
@@ -77,9 +78,12 @@ const hideOnEsc = {
 }
 
 .item {
-  text-align: left;
   background: transparent;
   border: none;
-  padding: 0.5rem 0.2rem;
+  padding: var(--cr-spacing-x-small);
+}
+.item:hover {
+  background-color: var(--cr-color-neutral-200);
+  cursor: pointer;
 }
 </style>

--- a/lib/src/index.css
+++ b/lib/src/index.css
@@ -71,6 +71,21 @@ html {
   max-width: var(--cr-sizes-max-page-width);
 }
 
+.whole-content {
+  width: 100%;
+  display: flex;
+  flex-flow: column;
+  gap: var(--cr-spacing-medium);
+  align-items: center;
+}
+
+.document-content {
+  max-width: var(--cr-sizes-max-page-width);
+  width: 100%;
+  display: flex;
+  flex-flow: column;
+}
+
 main {
   height: 100dvh;
   overflow: hidden;

--- a/skin/src/vue/c-content.vue
+++ b/skin/src/vue/c-content.vue
@@ -226,14 +226,6 @@ onUpdated(() => {
   display: block;
 }
 
-.whole-content {
-  width: 100%;
-  display: flex;
-  flex-flow: column;
-  gap: var(--cr-spacing-medium);
-  align-items: center;
-}
-
 .doc-header {
   display: flex;
   width: 100%;


### PR DESCRIPTION
* Adjusted styles for Tip Tap and bubble menu
* Moved styles from c-content.vue to index.css

# Jira URL

https://jira.xwiki.org/browse/CRISTAL-178

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* This branch changes some of the CSS issues when integrating Tiptap

## Clarifications

-

# Screenshots & Video

-

# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A