### PR TITLE
CRISTAL-203: Tables are missing CSS

### DIFF
--- a/editors/tiptap/src/vue/c-tiptap-link-suggest.vue
+++ b/editors/tiptap/src/vue/c-tiptap-link-suggest.vue
@@ -164,7 +164,7 @@ onUnmounted(() => {
   border: none;
   padding: var(--cr-spacing-x-small);
   width: 100%;
-  text-align: left;
+  text-align: start;
 }
 
 .information {

--- a/editors/tiptap/src/vue/c-tiptap-selector.vue
+++ b/editors/tiptap/src/vue/c-tiptap-selector.vue
@@ -129,7 +129,7 @@ const { down, up, enter, index } = listNavigation(
 .item {
   display: block;
   width: 100%;
-  text-align: left;
+  text-align: start;
   background: transparent;
   border: none;
   padding: 0.2rem 0.5rem;

--- a/skin/src/vue/c-content.vue
+++ b/skin/src/vue/c-content.vue
@@ -213,6 +213,45 @@ onUpdated(() => {
   justify-content: center;
 }
 
+/*TABLE STYLES*/
+/*TODO: Check a better way to write these styles without the global tag. Currently impossible to use :deep because the html inside the document content is not assigned an ID */
+
+:global(.document-content table) {
+  max-width: 100%;
+  width: 100%;
+  border: none;
+  border-collapse: collapse;
+  color: inherit;
+  margin-bottom: var(--cr-spacing-small);
+}
+
+:global(.document-content table tr) {
+  border-bottom: solid 1px var(--cr-input-border-color);
+}
+
+:global(.document-content table th) {
+  font-weight: var(--cr-font-weight-bold);
+  text-align: left;
+}
+
+:global(.document-content table td),
+:global(.document-content table th) {
+  line-height: var(--cr-line-height-normal);
+  padding: 1rem 1rem;
+}
+
+:global(.document-content table th p:first-child),
+:global(.document-content table td p:first-child) {
+  margin-top: 0;
+}
+
+:global(.document-content table th p:last-child),
+:global(.document-content table td p:last-child) {
+  margin-bottom: 0;
+}
+
+/*---*/
+
 .content-loading svg {
   width: 64px;
   height: 64px;

--- a/skin/src/vue/c-content.vue
+++ b/skin/src/vue/c-content.vue
@@ -231,7 +231,7 @@ onUpdated(() => {
 
 :global(.document-content table th) {
   font-weight: var(--cr-font-weight-bold);
-  text-align: left;
+  text-align: start;
 }
 
 :global(.document-content table td),


### PR DESCRIPTION
* Created basic styles for the tables

# Jira URL

https://jira.xwiki.org/browse/CRISTAL-203

# Changes

## Description

* Creates the basic styles for tables inside documents


## Clarifications

* For now, these styles are done with the ```:global``` tag because tables that come from the XWiki backend don't have any id, just basic HTML.

# Screenshots & Video

<img width="997" alt="Screenshot 2024-06-07 at 10 12 55" src="https://github.com/xwiki-contrib/cristal/assets/149672322/80a1487a-ed15-4b13-ac25-fc86a571e8cd">

# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A