### PR TITLE
CRISTAL-204: CSS for editing links

### DIFF
--- a/editors/tiptap/src/vue/c-tiptap-link-edit.vue
+++ b/editors/tiptap/src/vue/c-tiptap-link-edit.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { CIcon } from "@xwiki/cristal-icons";
+import { CIcon, Size } from "@xwiki/cristal-icons";
 import { BubbleMenuAction } from "../components/extensions/bubble-menu";
 import { Editor, Range } from "@tiptap/vue-3";
 import { inject, onMounted, onUpdated, Ref, ref } from "vue";
@@ -66,6 +66,7 @@ onUpdated(listenToLinks);
   <div class="container">
     <form
       ref="formRoot"
+      class="edit-link"
       title="Press enter to validate"
       @submit.prevent="submitLink"
     >
@@ -79,29 +80,30 @@ onUpdated(listenToLinks);
       />
       <!-- TODO: distinguish between following internal and external links? -->
       <x-btn
+        color="primary"
         title="Follow link"
-        variant="secondary"
+        variant="default"
         size="small"
         :disabled="!url || isAmbiguous"
       >
         <a v-if="url" :href="url">
-          <c-icon name="box-arrow-up-right"></c-icon>
+          <c-icon name="box-arrow-up-right" :size="Size.Small"></c-icon>
         </a>
-        <c-icon v-else name="box-arrow-up-right"></c-icon>
+        <c-icon v-else name="box-arrow-up-right" :size="Size.Small"></c-icon>
       </x-btn>
       <x-btn
         title="Remove link"
-        variant="secondary"
+        variant="default"
         size="small"
         @click="removeLink"
         @keydown.enter="removeLink"
       >
-        <c-icon name="x-circle-fill"></c-icon>
+        <c-icon name="x-circle-fill" :size="Size.Small"></c-icon>
       </x-btn>
       <x-btn
         v-if="hasWrapper"
         title="Go back"
-        variant="secondary"
+        variant="default"
         size="small"
         @click="close"
         @keydown.enter="close"
@@ -113,7 +115,24 @@ onUpdated(listenToLinks);
 </template>
 
 <style scoped>
+.edit-link {
+  display: flex;
+  gap: 8px;
+}
 .container {
-  padding: 0.2rem 0.5rem;
+  padding: var(--cr-spacing-x-small) var(--cr-spacing-small);
+}
+input {
+  width: 250px;
+  border-radius: 4px;
+}
+:deep(.button) {
+  padding: 0 var(--cr-spacing-x-small);
+  min-width: unset;
+  background-color: transparent !important;
+  border: 0;
+}
+:deep(.cr-icon) {
+  color: var(--cr-color-neutral-700);
 }
 </style>


### PR DESCRIPTION
* Adjusted styles for the editing links feature

# Jira URL

https://jira.xwiki.org/browse/CRISTAL-204

# Changes

## Description

* Add styles for editing links

## Clarifications



# Screenshots & Video

On Shoelace
<img width="421" alt="Screenshot 2024-06-10 at 07 46 44" src="https://github.com/xwiki-contrib/cristal/assets/149672322/75072f86-3af5-44f3-b073-707f52cb9621">

On Vuetify
<img width="446" alt="Screenshot 2024-06-10 at 07 48 18" src="https://github.com/xwiki-contrib/cristal/assets/149672322/2e26591d-72c5-4e94-b295-d93f2cebb957">


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A