### PR TITLE
CRISTAL-219: UI for creating pages

### DIFF
--- a/api/src/api/WikiConfig.ts
+++ b/api/src/api/WikiConfig.ts
@@ -63,4 +63,21 @@ export interface WikiConfig {
    * @since 0.9
    */
   getType(): string;
+
+  /**
+   * Returns the page resource separator for the current configuration.
+   * For instance, "." for XWiki, or "/" for Github and FileSystem.
+   *
+   * @returns the page resource separator
+   * @since 0.10
+   */
+  getPageResourceSeparator(): string;
+
+  /**
+   * Returns the default name for a newly created page.
+   *
+   * @returns the default name
+   * @since 0.10
+   */
+  getNewPageDefaultName(): string;
 }

--- a/api/src/components/defaultWikiConfig.ts
+++ b/api/src/components/defaultWikiConfig.ts
@@ -137,4 +137,12 @@ export class DefaultWikiConfig implements WikiConfig {
   getType(): string {
     return "Default";
   }
+
+  getPageResourceSeparator(): string {
+    return "/";
+  }
+
+  getNewPageDefaultName(): string {
+    return "newpage";
+  }
 }

--- a/core/backends/backend-xwiki/src/XWikiWikiConfig.ts
+++ b/core/backends/backend-xwiki/src/XWikiWikiConfig.ts
@@ -56,4 +56,12 @@ export class XWikiWikiConfig extends DefaultWikiConfig {
   override getType(): string {
     return "XWiki";
   }
+
+  override getPageResourceSeparator(): string {
+    return ".";
+  }
+
+  override getNewPageDefaultName(): string {
+    return "NewPage.WebHome";
+  }
 }

--- a/core/navigation-tree/navigation-tree-api/package.json
+++ b/core/navigation-tree/navigation-tree-api/package.json
@@ -21,6 +21,9 @@
     "clean": "rimraf dist",
     "build": "tsc --project tsconfig.json && vite build"
   },
+  "dependencies": {
+    "@xwiki/cristal-api": "workspace:*"
+  },
   "publishConfig": {
     "exports": {
       ".": {

--- a/core/navigation-tree/navigation-tree-api/src/index.ts
+++ b/core/navigation-tree/navigation-tree-api/src/index.ts
@@ -18,6 +18,8 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
+import type { PageData } from "@xwiki/cristal-api";
+
 /**
  * Description of a navigation tree node.
  * @since 0.10
@@ -25,6 +27,7 @@
 type NavigationTreeNode = {
   id: string;
   label: string;
+  location: string;
   url: string;
   has_children: boolean;
 };
@@ -43,6 +46,14 @@ interface NavigationTreeSource {
    * @returns the descendants in the navigation tree
    */
   getChildNodes(id?: string): Promise<Array<NavigationTreeNode>>;
+
+  /**
+   * Returns the ids of the parents nodes for a given page.
+   *
+   * @param page the data of the page
+   * @returns the parents nodes ids
+   **/
+  getParentNodesId(page?: PageData): Array<string>;
 }
 
 /**

--- a/core/navigation-tree/navigation-tree-default/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-default/src/components/componentsInit.ts
@@ -19,13 +19,14 @@
  */
 
 import { Container, inject, injectable } from "inversify";
-import type { CristalApp, Logger } from "@xwiki/cristal-api";
+import type { CristalApp, Logger, PageData } from "@xwiki/cristal-api";
 import {
   name as NavigationTreeSourceName,
   type NavigationTreeNode,
   type NavigationTreeSource,
   type NavigationTreeSourceProvider,
 } from "@xwiki/cristal-navigation-tree-api";
+import { getParentNodesIdFromPath } from "../utils";
 
 /**
  * Default implementation for NavigationTreeSource.
@@ -45,6 +46,10 @@ class DefaultNavigationTreeSource implements NavigationTreeSource {
 
   async getChildNodes(): Promise<Array<NavigationTreeNode>> {
     return [];
+  }
+
+  getParentNodesId(page?: PageData): Array<string> {
+    return getParentNodesIdFromPath(page);
   }
 }
 

--- a/core/navigation-tree/navigation-tree-default/src/utils.ts
+++ b/core/navigation-tree/navigation-tree-default/src/utils.ts
@@ -18,7 +18,27 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-import { getParentNodesIdFromPath } from "./utils";
+import type { PageData } from "@xwiki/cristal-api";
 
-export { ComponentInit, getParentNodesIdFromPath };
+/**
+ * Returns the ids of the parents nodes for a path-like page id.
+ *
+ * @param pageData the data of the page
+ * @returns the parents nodes ids
+ * @since 0.10
+ **/
+export function getParentNodesIdFromPath(page?: PageData): Array<string> {
+  const result: Array<string> = [];
+  if (page) {
+    const parents = page.id.split("/");
+    let currentParent = "";
+    let i;
+    for (i = 0; i < parents.length - 1; i++) {
+      currentParent += parents[i];
+      result.push(currentParent);
+      currentParent += "/";
+    }
+    result.push(page.id);
+  }
+  return result;
+}

--- a/core/navigation-tree/navigation-tree-filesystem/package.json
+++ b/core/navigation-tree/navigation-tree-filesystem/package.json
@@ -25,6 +25,7 @@
     "@xwiki/cristal-api": "workspace:*",
     "@xwiki/cristal-electron-storage": "workspace:*",
     "@xwiki/cristal-navigation-tree-api": "workspace:*",
+    "@xwiki/cristal-navigation-tree-default": "workspace:*",
     "inversify": "6.0.2"
   },
   "publishConfig": {

--- a/core/navigation-tree/navigation-tree-filesystem/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-filesystem/src/components/componentsInit.ts
@@ -19,12 +19,13 @@
  */
 
 import { Container, inject, injectable } from "inversify";
-import type { CristalApp, Logger } from "@xwiki/cristal-api";
+import type { CristalApp, Logger, PageData } from "@xwiki/cristal-api";
 import {
   name as NavigationTreeSourceName,
   type NavigationTreeNode,
   type NavigationTreeSource,
 } from "@xwiki/cristal-navigation-tree-api";
+import { getParentNodesIdFromPath } from "@xwiki/cristal-navigation-tree-default";
 
 /**
  * Implementation of NavigationTreeSource for the FileSystem backend.
@@ -63,6 +64,7 @@ class FileSystemNavigationTreeSource implements NavigationTreeSource {
         navigationTree.push({
           id: id,
           label: currentPageData ? currentPageData.name : child,
+          location: id,
           url: this.cristalApp.getRouter().resolve({
             name: "view",
             params: {
@@ -75,6 +77,10 @@ class FileSystemNavigationTreeSource implements NavigationTreeSource {
     }
 
     return navigationTree;
+  }
+
+  getParentNodesId(page?: PageData): Array<string> {
+    return getParentNodesIdFromPath(page);
   }
 }
 

--- a/core/navigation-tree/navigation-tree-github/package.json
+++ b/core/navigation-tree/navigation-tree-github/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@xwiki/cristal-api": "workspace:*",
     "@xwiki/cristal-navigation-tree-api": "workspace:*",
+    "@xwiki/cristal-navigation-tree-default": "workspace:*",
     "inversify": "6.0.2"
   },
   "publishConfig": {

--- a/core/navigation-tree/navigation-tree-github/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-github/src/components/componentsInit.ts
@@ -19,12 +19,13 @@
  */
 
 import { Container, inject, injectable } from "inversify";
-import type { CristalApp, Logger } from "@xwiki/cristal-api";
+import type { CristalApp, Logger, PageData } from "@xwiki/cristal-api";
 import {
   name as NavigationTreeSourceName,
   type NavigationTreeNode,
   type NavigationTreeSource,
 } from "@xwiki/cristal-navigation-tree-api";
+import { getParentNodesIdFromPath } from "@xwiki/cristal-navigation-tree-default";
 
 /**
  * Implementation of NavigationTreeSource for the GitHub backend.
@@ -69,6 +70,7 @@ class GitHubNavigationTreeSource implements NavigationTreeSource {
           navigationTree.push({
             id: treeNode.path,
             label: treeNode.name,
+            location: treeNode.path,
             url: this.cristalApp.getRouter().resolve({
               name: "view",
               params: {
@@ -84,6 +86,10 @@ class GitHubNavigationTreeSource implements NavigationTreeSource {
       this.logger.debug("Could not load navigation tree.");
     }
     return navigationTree;
+  }
+
+  getParentNodesId(page?: PageData): Array<string> {
+    return getParentNodesIdFromPath(page);
   }
 }
 

--- a/core/navigation-tree/navigation-tree-nextcloud/package.json
+++ b/core/navigation-tree/navigation-tree-nextcloud/package.json
@@ -24,6 +24,7 @@
   "dependencies": {
     "@xwiki/cristal-api": "workspace:*",
     "@xwiki/cristal-navigation-tree-api": "workspace:*",
+    "@xwiki/cristal-navigation-tree-default": "workspace:*",
     "inversify": "6.0.2"
   },
   "publishConfig": {

--- a/core/navigation-tree/navigation-tree-nextcloud/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-nextcloud/src/components/componentsInit.ts
@@ -19,12 +19,13 @@
  */
 
 import { Container, inject, injectable } from "inversify";
-import type { CristalApp, Logger } from "@xwiki/cristal-api";
+import type { CristalApp, Logger, PageData } from "@xwiki/cristal-api";
 import {
   name as NavigationTreeSourceName,
   type NavigationTreeNode,
   type NavigationTreeSource,
 } from "@xwiki/cristal-navigation-tree-api";
+import { getParentNodesIdFromPath } from "@xwiki/cristal-navigation-tree-default";
 
 /**
  * Implementation of NavigationTreeSource for the Nextcloud backend.
@@ -57,6 +58,7 @@ class NextcloudNavigationTreeSource implements NavigationTreeSource {
       navigationTree.push({
         id: d,
         label: currentPageData ? currentPageData.name : d.split("/").pop()!,
+        location: d,
         url: this.cristalApp.getRouter().resolve({
           name: "view",
           params: {
@@ -110,6 +112,10 @@ class NextcloudNavigationTreeSource implements NavigationTreeSource {
     }
 
     return subdirectories;
+  }
+
+  getParentNodesId(page?: PageData): Array<string> {
+    return getParentNodesIdFromPath(page);
   }
 
   private getBaseHeaders() {

--- a/core/navigation-tree/navigation-tree-xwiki/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-xwiki/src/components/componentsInit.ts
@@ -19,7 +19,7 @@
  */
 
 import { Container, inject, injectable } from "inversify";
-import type { CristalApp, Logger } from "@xwiki/cristal-api";
+import type { CristalApp, Logger, PageData } from "@xwiki/cristal-api";
 import {
   name as NavigationTreeSourceName,
   type NavigationTreeNode,
@@ -78,19 +78,21 @@ class XWikiNavigationTreeSource implements NavigationTreeSource {
           a_attr: { href: string };
         }) => {
           if (!["attachments", "translations"].includes(treeNode.data.type)) {
+            const pageId = decodeURIComponent(
+              this.cristalApp
+                .getWikiConfig()
+                .storage.getPageFromViewURL(
+                  `${baseXWikiURL}${treeNode.a_attr.href}`,
+                )!,
+            );
             navigationTree.push({
               id: treeNode.id,
               label: treeNode.text,
+              location: pageId.replace(/\.WebHome$/, ""),
               url: this.cristalApp.getRouter().resolve({
                 name: "view",
                 params: {
-                  page: decodeURIComponent(
-                    this.cristalApp
-                      .getWikiConfig()
-                      .storage.getPageFromViewURL(
-                        `${baseXWikiURL}${treeNode.a_attr.href}`,
-                      )!,
-                  ),
+                  page: pageId,
                 },
               }).href,
               has_children: treeNode.children, //TODO: ignore translations and attachments
@@ -103,6 +105,32 @@ class XWikiNavigationTreeSource implements NavigationTreeSource {
       this.logger.debug("Could not load navigation tree.");
     }
     return navigationTree;
+  }
+
+  getParentNodesId(page?: PageData): Array<string> {
+    const result = [];
+    if (page) {
+      const documentId = page.document.getIdentifier();
+      if (!documentId) {
+        this.logger.debug(
+          `No identifier found for page ${page.name}, cannot resolve parents.`,
+        );
+        return [];
+      }
+      const parents = documentId
+        .replace(/\.WebHome$/, "")
+        .split(/(?<![^\\](?:\\\\)*\\)\./);
+      let currentParent = "";
+      let i;
+      for (i = 0; i < parents.length - 1; i++) {
+        currentParent += parents[i];
+        // TODO: Support subwikis.
+        result.push(`document:xwiki:${currentParent}.WebHome`);
+        currentParent += ".";
+      }
+      result.push(`document:xwiki:${documentId}`);
+    }
+    return result;
   }
 }
 

--- a/ds/shoelace/src/vue/form/x-form.vue
+++ b/ds/shoelace/src/vue/form/x-form.vue
@@ -11,4 +11,8 @@ function submit() {
   </form>
 </template>
 
-<style scoped></style>
+<style scoped>
+form {
+  padding: 16px;
+}
+</style>

--- a/ds/shoelace/src/vue/form/x-text-field.vue
+++ b/ds/shoelace/src/vue/form/x-text-field.vue
@@ -3,6 +3,8 @@ import { type TextFieldProps } from "@xwiki/cristal-dsapi";
 import "@shoelace-style/shoelace/dist/components/input/input";
 
 defineProps<TextFieldProps>();
+
+const input = defineModel<string>();
 </script>
 
 <template>
@@ -10,7 +12,9 @@ defineProps<TextFieldProps>();
     :label="label"
     :name="name"
     :required="required"
+    :value="input"
     type="text"
+    @input="input = $event.target.value"
   ></sl-input>
 </template>
 

--- a/ds/shoelace/src/vue/x-dialog.vue
+++ b/ds/shoelace/src/vue/x-dialog.vue
@@ -19,21 +19,30 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 -->
 <script lang="ts" setup>
 import "@shoelace-style/shoelace/dist/components/dialog/dialog";
-import { ref } from "vue";
 
-defineProps<{ class: string; title: string }>();
-
-const dialog = ref();
+defineProps<{
+  title: string;
+  width: string | number | undefined;
+}>();
 
 function click() {
-  dialog.value.show();
+  open.value = true;
 }
+
+const open = defineModel<boolean>();
 </script>
 <template>
   <span @click="click">
     <slot name="activator" />
   </span>
-  <sl-dialog ref="dialog" :label="title" class="dialog-overview">
+  <sl-dialog
+    :open="open"
+    :label="title"
+    :style="`--width: ${width}; --body-spacing: 0 1.25rem 1.25rem`"
+    class="dialog-overview"
+    @sl-show="open = true"
+    @sl-hide="open = false"
+  >
     <slot name="default" />
   </sl-dialog>
 </template>

--- a/ds/shoelace/src/vue/x-navigation-tree.vue
+++ b/ds/shoelace/src/vue/x-navigation-tree.vue
@@ -18,22 +18,97 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <script setup lang="ts">
-import { Ref, onBeforeMount, ref } from "vue";
+import { type Ref, onBeforeMount, onMounted, ref, watch } from "vue";
 import "@shoelace-style/shoelace/dist/components/tree/tree";
 import "@shoelace-style/shoelace/dist/components/tree-item/tree-item";
+import type SlTree from "@shoelace-style/shoelace/dist/components/tree/tree";
+import type SlTreeItem from "@shoelace-style/shoelace/dist/components/tree-item/tree-item";
+import { type PageData } from "@xwiki/cristal-api";
 import type {
   NavigationTreeNode,
   NavigationTreeSource,
 } from "@xwiki/cristal-navigation-tree-api";
 
+type OnClickAction = (node: NavigationTreeNode) => void;
+
+const mutationObserver: MutationObserver = new MutationObserver(onMutation);
+
 const rootNodes: Ref<Array<NavigationTreeNode>> = ref([]);
+const tree: Ref<SlTree | undefined> = ref(undefined);
+const treeItems: Ref<Map<string, SlTreeItem>> = ref(
+  new Map<string, SlTreeItem>(),
+);
+var selectedTreeItem: SlTreeItem | undefined = undefined;
+
+var expandedNodes: Array<string> = new Array<string>();
+var expandNodes: boolean = false;
+
 const props = defineProps<{
   treeResolver: NavigationTreeSource;
+  clickAction?: OnClickAction;
+  currentPage?: PageData;
 }>();
 
 onBeforeMount(async () => {
   rootNodes.value.push(...(await props.treeResolver.getChildNodes("")));
 });
+
+onMounted(() => mutationObserver.observe(tree.value!, { childList: true }));
+watch(
+  () => props.currentPage,
+  () => {
+    if (props.currentPage) {
+      expandNodes = true;
+      expandedNodes = props.treeResolver.getParentNodesId(props.currentPage);
+      expandTree();
+    }
+  },
+  { immediate: true },
+);
+watch(treeItems, expandTree, { deep: true });
+
+function expandTree() {
+  if (expandNodes) {
+    let i;
+    for (i = 0; i < expandedNodes.length - 1; i++) {
+      if (treeItems.value.has(expandedNodes[i])) {
+        treeItems.value.get(expandedNodes[i])!.expanded = true;
+      }
+    }
+    if (treeItems.value.has(expandedNodes[i])) {
+      if (selectedTreeItem) {
+        selectedTreeItem.selected = false;
+      }
+      treeItems.value.get(expandedNodes[i])!.selected = true;
+      selectedTreeItem = treeItems.value.get(expandedNodes[i]);
+      // If we have a custom click action, we want to use it on dynamic
+      // selection.
+      if (props.clickAction) {
+        selectedTreeItem?.getElementsByTagName("a")[0].click();
+      }
+      expandNodes = false;
+    }
+  }
+}
+
+function onMutation(mutationList: Array<MutationRecord>) {
+  for (const mutation of mutationList) {
+    if (mutation.type === "childList") {
+      mutation.addedNodes.forEach((node) => {
+        const item = node as SlTreeItem;
+        mutationObserver.observe(item, { childList: true });
+        item.updateComplete.then(() => {
+          treeItems.value.set(item.getAttribute("data-id")!, item);
+        });
+      });
+    }
+  }
+}
+
+function onSelectionChange(event: unknown) {
+  selectedTreeItem = (event as { detail: { selection: SlTreeItem[] } }).detail
+    .selection[0];
+}
 
 function lazyLoadChildren(id: string) {
   return async (event: Event) => {
@@ -41,16 +116,26 @@ function lazyLoadChildren(id: string) {
     const childNodes = await props.treeResolver.getChildNodes(id);
     for (const child of childNodes) {
       const treeItem = document.createElement("sl-tree-item");
-      treeItem.innerHTML = `<a href="${child.url}">${child.label
+      const label = child.label
         .replace(/&/g, "&amp;")
         .replace(/>/g, "&gt;")
-        .replace(/</g, "&lt;")}</a>`;
+        .replace(/</g, "&lt;");
+      treeItem.innerHTML = `<a href="${child.url}">${label}</a>`;
+      if (props.clickAction) {
+        treeItem
+          .getElementsByTagName("a")[0]
+          .addEventListener("click", (event) => {
+            props.clickAction!(child);
+            event.preventDefault();
+          });
+      }
       if (child.has_children) {
         treeItem.setAttribute("lazy", "true");
         treeItem.addEventListener("sl-lazy-load", lazyLoadChildren(child.id), {
           once: true,
         });
       }
+      treeItem.setAttribute("data-id", child.id);
       lazyItem.append(treeItem);
     }
 
@@ -69,14 +154,21 @@ function lazyLoadChildren(id: string) {
 </script>
 
 <template>
-  <sl-tree>
+  <sl-tree ref="tree" @sl-selection-change="onSelectionChange($event)">
     <sl-tree-item
       v-for="item in rootNodes"
       :key="item.id"
       :lazy="item.has_children"
+      :data-id="item.id"
       @sl-lazy-load.once="lazyLoadChildren(item.id)($event)"
     >
-      <a :href="item.url">{{ item.label }}</a>
+      <a
+        v-if="props.clickAction"
+        :href="item.url"
+        @click.prevent="clickAction!(item)"
+        >{{ item.label }}</a
+      >
+      <a v-else :href="item.url">{{ item.label }}</a>
     </sl-tree-item>
   </sl-tree>
 </template>

--- a/ds/vuetify/package.json
+++ b/ds/vuetify/package.json
@@ -32,7 +32,7 @@
     "inversify": "6.0.2",
     "vue": "3.4.31",
     "vue-i18n": "9.13.1",
-    "vuetify": "3.6.10"
+    "vuetify": "3.6.15"
   },
   "devDependencies": {
     "vue-tsc": "2.0.22"

--- a/ds/vuetify/src/vue/x-navigation-tree.vue
+++ b/ds/vuetify/src/vue/x-navigation-tree.vue
@@ -18,21 +18,34 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <script setup lang="ts">
-import { Ref, onBeforeMount, ref } from "vue";
+import { Ref, onBeforeMount, ref, watch } from "vue";
 import { VTreeview } from "vuetify/labs/VTreeview";
-
-import type { NavigationTreeSource } from "@xwiki/cristal-navigation-tree-api";
+import { type PageData } from "@xwiki/cristal-api";
+import type {
+  NavigationTreeSource,
+  NavigationTreeNode,
+} from "@xwiki/cristal-navigation-tree-api";
 
 type TreeItem = {
   id: string;
   title: string;
   href: string;
   children?: Array<TreeItem>;
+  _location: string;
 };
 
+type OnClickAction = (node: NavigationTreeNode) => void;
+
 const rootNodes: Ref<Array<TreeItem>> = ref([]);
+const tree: Ref<VTreeview | undefined> = ref(undefined);
+
+const activatedNodes: Ref<Array<string>> = ref(new Array<string>());
+const expandedNodes: Ref<Array<string>> = ref(new Array<string>());
+
 const props = defineProps<{
   treeResolver: NavigationTreeSource;
+  clickAction?: OnClickAction;
+  currentPage?: PageData;
 }>();
 
 onBeforeMount(async () => {
@@ -42,9 +55,63 @@ onBeforeMount(async () => {
       title: node.label,
       href: node.url,
       children: node.has_children ? [] : undefined,
+      _location: node.location,
     });
   }
+  if (props.currentPage !== undefined) {
+    await expandTree();
+  }
 });
+
+watch(
+  () => props.currentPage,
+  async () => {
+    if (props.currentPage) {
+      await expandTree();
+    }
+  },
+);
+
+async function expandTree() {
+  const newExpandedNodes = props.treeResolver.getParentNodesId(
+    props.currentPage,
+  );
+  let i;
+  let currentNodes = rootNodes.value;
+  for (i = 0; i < newExpandedNodes.length - 1; i++) {
+    if (currentNodes) {
+      for (const node of currentNodes) {
+        if (node.id == newExpandedNodes[i]) {
+          if (node.children?.length == 0) {
+            await lazyLoadChildren(node);
+          }
+          if (!expandedNodes.value.includes(node.id)) {
+            expandedNodes.value.push(node.id);
+          }
+          currentNodes = node.children!;
+        }
+      }
+    }
+  }
+  if (currentNodes) {
+    for (const node of currentNodes) {
+      if (node.id == newExpandedNodes[i]) {
+        activatedNodes.value = [node.id];
+        // If we have a custom click action, we want to use it on dynamic
+        // selection.
+        if (props.clickAction) {
+          props.clickAction({
+            id: node.id,
+            label: node.title,
+            location: node._location,
+            url: node.href,
+            has_children: node.children !== undefined,
+          });
+        }
+      }
+    }
+  }
+}
 
 async function lazyLoadChildren(item: unknown) {
   const treeItem = item as TreeItem;
@@ -55,6 +122,7 @@ async function lazyLoadChildren(item: unknown) {
       title: child.label,
       href: child.url,
       children: child.has_children ? [] : undefined,
+      _location: child.location,
     });
   }
   // If the node doesn't have any children, we update it.
@@ -66,14 +134,32 @@ async function lazyLoadChildren(item: unknown) {
 
 <template>
   <v-treeview
+    ref="tree"
+    v-model:activated="activatedNodes"
+    v-model:opened="expandedNodes"
     :items="rootNodes"
     :load-children="lazyLoadChildren"
     activatable
-    active-strategy="independent"
+    active-strategy="single-independent"
+    item-value="id"
     open-strategy="multiple"
   >
     <template #title="{ item }: { item: any }">
-      <a :href="item.href">{{ item.title }}</a>
+      <a
+        v-if="props.clickAction"
+        :href="item.href"
+        @click.prevent="
+          clickAction!({
+            id: item.id,
+            label: item.title,
+            location: item._location,
+            url: item.href,
+            has_children: item.children !== undefined,
+          })
+        "
+        >{{ item.title }}</a
+      >
+      <a v-else :href="item.href">{{ item.title }}</a>
     </template>
   </v-treeview>
 </template>

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -420,7 +420,11 @@ importers:
         specifier: 6.0.2
         version: 6.0.2
 
-  core/navigation-tree/navigation-tree-api: {}
+  core/navigation-tree/navigation-tree-api:
+    dependencies:
+      '@xwiki/cristal-api':
+        specifier: workspace:*
+        version: link:../../../api
 
   core/navigation-tree/navigation-tree-default:
     dependencies:
@@ -445,6 +449,9 @@ importers:
       '@xwiki/cristal-navigation-tree-api':
         specifier: workspace:*
         version: link:../navigation-tree-api
+      '@xwiki/cristal-navigation-tree-default':
+        specifier: workspace:*
+        version: link:../navigation-tree-default
       inversify:
         specifier: 6.0.2
         version: 6.0.2
@@ -457,6 +464,9 @@ importers:
       '@xwiki/cristal-navigation-tree-api':
         specifier: workspace:*
         version: link:../navigation-tree-api
+      '@xwiki/cristal-navigation-tree-default':
+        specifier: workspace:*
+        version: link:../navigation-tree-default
       inversify:
         specifier: 6.0.2
         version: 6.0.2
@@ -469,6 +479,9 @@ importers:
       '@xwiki/cristal-navigation-tree-api':
         specifier: workspace:*
         version: link:../navigation-tree-api
+      '@xwiki/cristal-navigation-tree-default':
+        specifier: workspace:*
+        version: link:../navigation-tree-default
       inversify:
         specifier: 6.0.2
         version: 6.0.2
@@ -575,8 +588,8 @@ importers:
         specifier: 9.13.1
         version: 9.13.1(vue@3.4.31(typescript@5.5.2))
       vuetify:
-        specifier: 3.6.10
-        version: 3.6.10(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
+        specifier: 3.6.15
+        version: 3.6.15(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
     devDependencies:
       vue-tsc:
         specifier: 2.0.22
@@ -1209,7 +1222,7 @@ importers:
         version: 0.8.4(rollup@4.18.0)(vite@5.3.2(@types/node@20.14.9))
       vite-plugin-vuetify:
         specifier: 2.0.3
-        version: 2.0.3(vite@5.3.2(@types/node@20.14.9))(vue@3.4.31(typescript@5.5.2))(vuetify@3.7.0)
+        version: 2.0.3(vite@5.3.2(@types/node@20.14.9))(vue@3.4.31(typescript@5.5.2))(vuetify@3.7.1)
       vue-tsc:
         specifier: 2.0.22
         version: 2.0.22(typescript@5.5.2)
@@ -5129,8 +5142,8 @@ packages:
       typescript:
         optional: true
 
-  vuetify@3.6.10:
-    resolution: {integrity: sha512-Myd9+EFq4Gmu61yKPNVS0QdGQkcZ9cHom27wuvRw7jgDxM+X4MT9BwQRk/Dt1q3G3JlK8oh+ZYyq5Ps/Z73cMg==}
+  vuetify@3.6.15:
+    resolution: {integrity: sha512-lg5Si+vX0hQpO4EzI9f+8JNVHbjV//E99yKif7OuWLENDk1TQx2tfqCdZvb5AnAeqyiqVJVgOQp4uYHgGjTFAw==}
     engines: {node: ^12.20 || >=14.13}
     peerDependencies:
       typescript: '>=4.7'
@@ -5148,21 +5161,18 @@ packages:
       webpack-plugin-vuetify:
         optional: true
 
-  vuetify@3.7.0:
-    resolution: {integrity: sha512-x+UaU4SPYNcJSE/voCTBFrNn0q9Spzx2EMfDdUj0NYgHGKb59OqnZte+AjaJaoOXy1AHYIGEpm5Ryk2BEfgWuw==}
+  vuetify@3.7.1:
+    resolution: {integrity: sha512-N1XlczbgeGt/O+JUk72QPrqcDaRIXUdptUciJqGyTvZ9cfMoSlEWs6TZO+dOOfXbKvmIMFMycYg4dgSHDpCPhg==}
     engines: {node: ^12.20 || >=14.13}
     peerDependencies:
       typescript: '>=4.7'
       vite-plugin-vuetify: '>=1.0.0'
       vue: ^3.3.0
-      vue-i18n: ^9.0.0
       webpack-plugin-vuetify: '>=2.0.0'
     peerDependenciesMeta:
       typescript:
         optional: true
       vite-plugin-vuetify:
-        optional: true
-      vue-i18n:
         optional: true
       webpack-plugin-vuetify:
         optional: true
@@ -6705,18 +6715,18 @@ snapshots:
       js-beautify: 1.14.11
       vue-component-type-helpers: 2.0.7
 
-  '@vuetify/loader-shared@2.0.3(vue@3.4.31(typescript@5.5.2))(vuetify@3.6.10(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2)))':
+  '@vuetify/loader-shared@2.0.3(vue@3.4.31(typescript@5.5.2))(vuetify@3.6.15(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2)))':
     dependencies:
       upath: 2.0.1
       vue: 3.4.31(typescript@5.5.2)
-      vuetify: 3.6.10(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
+      vuetify: 3.6.15(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
     optional: true
 
-  '@vuetify/loader-shared@2.0.3(vue@3.4.31(typescript@5.5.2))(vuetify@3.7.0(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2)))':
+  '@vuetify/loader-shared@2.0.3(vue@3.4.31(typescript@5.5.2))(vuetify@3.7.1(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue@3.4.31(typescript@5.5.2)))':
     dependencies:
       upath: 2.0.1
       vue: 3.4.31(typescript@5.5.2)
-      vuetify: 3.7.0(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
+      vuetify: 3.7.1(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue@3.4.31(typescript@5.5.2))
 
   '@xmldom/xmldom@0.8.10': {}
 
@@ -9539,26 +9549,26 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-vuetify@2.0.3(vite@5.3.2(@types/node@20.14.9))(vue@3.4.31(typescript@5.5.2))(vuetify@3.6.10):
+  vite-plugin-vuetify@2.0.3(vite@5.3.2(@types/node@20.14.9))(vue@3.4.31(typescript@5.5.2))(vuetify@3.6.15):
     dependencies:
-      '@vuetify/loader-shared': 2.0.3(vue@3.4.31(typescript@5.5.2))(vuetify@3.6.10(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2)))
+      '@vuetify/loader-shared': 2.0.3(vue@3.4.31(typescript@5.5.2))(vuetify@3.6.15(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2)))
       debug: 4.3.4(supports-color@5.5.0)
       upath: 2.0.1
       vite: 5.3.2(@types/node@20.14.9)
       vue: 3.4.31(typescript@5.5.2)
-      vuetify: 3.6.10(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
+      vuetify: 3.6.15(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
     transitivePeerDependencies:
       - supports-color
     optional: true
 
-  vite-plugin-vuetify@2.0.3(vite@5.3.2(@types/node@20.14.9))(vue@3.4.31(typescript@5.5.2))(vuetify@3.7.0):
+  vite-plugin-vuetify@2.0.3(vite@5.3.2(@types/node@20.14.9))(vue@3.4.31(typescript@5.5.2))(vuetify@3.7.1):
     dependencies:
-      '@vuetify/loader-shared': 2.0.3(vue@3.4.31(typescript@5.5.2))(vuetify@3.7.0(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2)))
+      '@vuetify/loader-shared': 2.0.3(vue@3.4.31(typescript@5.5.2))(vuetify@3.7.1(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue@3.4.31(typescript@5.5.2)))
       debug: 4.3.4(supports-color@5.5.0)
       upath: 2.0.1
       vite: 5.3.2(@types/node@20.14.9)
       vue: 3.4.31(typescript@5.5.2)
-      vuetify: 3.7.0(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2))
+      vuetify: 3.7.1(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue@3.4.31(typescript@5.5.2))
     transitivePeerDependencies:
       - supports-color
 
@@ -9671,21 +9681,20 @@ snapshots:
     optionalDependencies:
       typescript: 5.5.2
 
-  vuetify@3.6.10(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2)):
+  vuetify@3.6.15(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2)):
     dependencies:
       vue: 3.4.31(typescript@5.5.2)
     optionalDependencies:
       typescript: 5.5.2
-      vite-plugin-vuetify: 2.0.3(vite@5.3.2(@types/node@20.14.9))(vue@3.4.31(typescript@5.5.2))(vuetify@3.6.10)
+      vite-plugin-vuetify: 2.0.3(vite@5.3.2(@types/node@20.14.9))(vue@3.4.31(typescript@5.5.2))(vuetify@3.6.15)
       vue-i18n: 9.13.1(vue@3.4.31(typescript@5.5.2))
 
-  vuetify@3.7.0(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue-i18n@9.13.1(vue@3.4.31(typescript@5.5.2)))(vue@3.4.31(typescript@5.5.2)):
+  vuetify@3.7.1(typescript@5.5.2)(vite-plugin-vuetify@2.0.3)(vue@3.4.31(typescript@5.5.2)):
     dependencies:
       vue: 3.4.31(typescript@5.5.2)
     optionalDependencies:
       typescript: 5.5.2
-      vite-plugin-vuetify: 2.0.3(vite@5.3.2(@types/node@20.14.9))(vue@3.4.31(typescript@5.5.2))(vuetify@3.7.0)
-      vue-i18n: 9.13.1(vue@3.4.31(typescript@5.5.2))
+      vite-plugin-vuetify: 2.0.3(vite@5.3.2(@types/node@20.14.9))(vue@3.4.31(typescript@5.5.2))(vuetify@3.7.1)
 
   w3c-keyname@2.2.8: {}
 

--- a/skin/src/vue/c-page-creation-menu.vue
+++ b/skin/src/vue/c-page-creation-menu.vue
@@ -1,0 +1,118 @@
+<!--
+See the LICENSE file distributed with this work for additional
+information regarding copyright ownership.
+
+This is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2.1 of
+the License, or (at your option) any later version.
+
+This software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this software; if not, write to the Free
+Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+<script setup lang="ts">
+import { type Ref, defineProps, inject, ref } from "vue";
+import type { CristalApp, PageData } from "@xwiki/cristal-api";
+import type {
+  NavigationTreeNode,
+  NavigationTreeSourceProvider,
+} from "@xwiki/cristal-navigation-tree-api";
+import { CIcon } from "@xwiki/cristal-icons";
+
+const cristal: CristalApp = inject<CristalApp>("cristal")!;
+
+const dialogOpen: Ref<boolean> = ref(false);
+const name: Ref<string> = ref("");
+const location: Ref<string> = ref("");
+
+defineProps<{
+  currentPage: PageData;
+}>();
+
+function treeNodeClickAction(node: NavigationTreeNode) {
+  location.value = node.location;
+}
+
+function updateCurrentPage() {
+  name.value = cristal.getWikiConfig().getNewPageDefaultName();
+}
+
+function createPage() {
+  var newPage = "";
+  if (location.value) {
+    newPage +=
+      location.value + cristal.getWikiConfig().getPageResourceSeparator();
+  }
+  newPage += name.value;
+
+  cristal.setCurrentPage(newPage, "edit");
+
+  dialogOpen.value = false;
+}
+</script>
+
+<template>
+  <x-dialog v-model="dialogOpen" width="auto" title="New Page">
+    <template #activator="{ props }">
+      <span id="new-page-button" @click="updateCurrentPage">
+        <c-icon name="plus" v-bind="props"></c-icon>
+        <strong>New Page</strong>
+      </span>
+    </template>
+    <template #default>
+      <div id="new-page-content">
+        <x-form>
+          <x-text-field
+            v-model="name"
+            label="Name"
+            name="name"
+            required
+          ></x-text-field>
+          <x-text-field
+            v-model="location"
+            label="Location"
+            name="location"
+            required
+          ></x-text-field>
+        </x-form>
+        <div id="new-page-navigation-tree">
+          <XNavigationTree
+            :tree-resolver="
+              cristal
+                .getContainer()
+                .get<NavigationTreeSourceProvider>(
+                  'NavigationTreeSourceProvider',
+                )
+                .get()
+            "
+            :click-action="treeNodeClickAction"
+            :current-page="currentPage"
+          ></XNavigationTree>
+        </div>
+        <x-btn @click="createPage">Create</x-btn>
+      </div>
+    </template>
+  </x-dialog>
+</template>
+
+<style scoped>
+#new-page-button {
+  cursor: pointer;
+}
+#new-page-content {
+  min-width: 600px;
+}
+#new-page-navigation-tree {
+  height: 400px;
+  border: thin solid var(--cr-color-neutral-200);
+  margin-bottom: 1rem;
+  overflow: auto;
+}
+</style>

--- a/skin/src/vue/c-sidebar.vue
+++ b/skin/src/vue/c-sidebar.vue
@@ -19,9 +19,11 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 -->
 <script lang="ts" setup>
 import { Ref, inject, onMounted, ref, watch } from "vue";
-import { type CristalApp } from "@xwiki/cristal-api";
+import { useRoute } from "vue-router";
+import type { CristalApp, PageData } from "@xwiki/cristal-api";
 import type { NavigationTreeSourceProvider } from "@xwiki/cristal-navigation-tree-api";
 import CConfigMenu from "./c-config-menu.vue";
+import CPageCreationMenu from "./c-page-creation-menu.vue";
 import CNavigationDrawer from "./c-navigation-drawer.vue";
 import CSidebarPanel from "./c-sidebar-panel.vue";
 import CHelp from "./c-help.vue";
@@ -40,6 +42,8 @@ const isSidebarClosed: Ref<boolean> = ref(
   viewportType.value == ViewportType.Mobile,
 );
 
+const route = useRoute();
+const currentPage: Ref<PageData | undefined> = ref(undefined);
 const cristal: CristalApp = inject<CristalApp>("cristal")!;
 
 defineEmits(["collapseLeftSidebar"]);
@@ -55,6 +59,14 @@ onMounted(() => {
   }
 });
 
+watch(
+  () => route.params.page,
+  async () => {
+    const pageName = (route.params.page as string) || cristal.getCurrentPage();
+    currentPage.value = await cristal.getPage(pageName);
+  },
+  { immediate: true },
+);
 watch(viewportType, (newViewportType: ViewportType) => {
   // Always close left sidebar when switching to a smaller viewport
   if (newViewportType == ViewportType.Mobile) {
@@ -154,6 +166,9 @@ function onClickOutsideLeftSidebar() {
     </div>
     <div class="panel-container">
       <c-sidebar-panel name="Wiki Name">
+        <c-page-creation-menu
+          :current-page="currentPage!"
+        ></c-page-creation-menu>
         <XNavigationTree
           :tree-resolver="
             cristal
@@ -161,6 +176,7 @@ function onClickOutsideLeftSidebar() {
               .get<NavigationTreeSourceProvider>('NavigationTreeSourceProvider')
               .get()
           "
+          :current-page="currentPage"
         ></XNavigationTree>
       </c-sidebar-panel>
       <c-sidebar-panel name="Applications"></c-sidebar-panel>

--- a/web/e2e/pageObjects/NavigationTree.ts
+++ b/web/e2e/pageObjects/NavigationTree.ts
@@ -48,7 +48,7 @@ export class NavigationTreePageObject {
 
   private async findItemsShoelace(): Promise<Array<NavigationTreeNode>> {
     return await NavigationTreePageObject.findItemsInternal(
-      this.page.locator("#sidebar sl-tree sl-tree-item"),
+      this.page.locator("#sidebar sl-tree").nth(1).locator("sl-tree-item"),
       NavigationTreePageObject.wrapShoelace);
   }
 


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-219

# Changes

## Description

* Add New Page dialog to the sidebar: `CPageCreationMenu`
* Make navigation trees react to current page changes
* Add prop to `XNavigationTree` to override default click action
* Introduce `NavigationTreeSource.getParentNodesId()`
* Introduce `WikiConfig.getPageResourceSeparator()`
* Introduce `WikiConfig.getNewPageDefaultName()`
* Introduce property `NavigationTreeNode.location`
* Implement missing model on Shoelace's `XTextField`
* Implement missing model on Shoelace's `XDialog`
* Slightly unify CSS between Shoelace and Vuetify components
* Update `vuetify` to version `3.6.15`

## Clarifications

The changes to the Navigation Tree will only work for the Nextcloud backend after [this PR](https://github.com/xwiki-contrib/cristal/pull/336) is merged.

`vuetify` was updated to the last iteration of `3.6.x` in order to fix some bugs with `VTreeview`.  Updating to `3.7.x` will need to be postponed until https://github.com/vuetifyjs/vuetify/issues/20460 is resolved.

# Screenshots & Video

Shoelace
![image](https://github.com/user-attachments/assets/418693ab-b159-4cf3-a4ff-06da74a6a3c9)

Vuetify
![image](https://github.com/user-attachments/assets/3da8def7-c4c4-4d94-978f-2c8ece570c46)

# Executed Tests

Everything was tested manually and the test suite was run succesfully.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A