### PR TITLE
CRISTAL-244: Clicking outside the text in the navigation tree nodes does nothing

### DIFF
--- a/ds/shoelace/src/utils/navigation-tree-selection.ts
+++ b/ds/shoelace/src/utils/navigation-tree-selection.ts
@@ -1,0 +1,29 @@
+import { type Ref } from "vue";
+import type SlTreeItem from "@shoelace-style/shoelace/dist/components/tree-item/tree-item";
+
+export class NavigationTreeSelection {
+  private selectedTreeItem: SlTreeItem | undefined = undefined;
+  private treeItems: Ref<Map<string, SlTreeItem>>;
+
+  constructor(treeItems: Ref<Map<string, SlTreeItem>>) {
+    this.treeItems = treeItems;
+  }
+
+  public updateSelection(id: string) {
+    if (this.selectedTreeItem) {
+      this.selectedTreeItem.selected = false;
+    }
+    this.selectedTreeItem = this.treeItems.value.get(id);
+    this.selectedTreeItem!.selected = true;
+  }
+
+  public onSelectionChange(event: unknown) {
+    // We don't want users to manually select a node, so we undo any change.
+    (
+      event as { detail: { selection: SlTreeItem[] } }
+    ).detail.selection[0].selected = false;
+    if (this.selectedTreeItem) {
+      this.selectedTreeItem!.selected = true;
+    }
+  }
+}

--- a/ds/shoelace/src/utils/navigation-tree-selection.ts
+++ b/ds/shoelace/src/utils/navigation-tree-selection.ts
@@ -17,6 +17,10 @@ export class NavigationTreeSelection {
     this.selectedTreeItem!.selected = true;
   }
 
+  public getSelection(): SlTreeItem | undefined {
+    return this.selectedTreeItem;
+  }
+
   public onSelectionChange(event: unknown) {
     // We don't want users to manually select a node, so we undo any change.
     (

--- a/ds/shoelace/src/utils/navigation-tree-selection.ts
+++ b/ds/shoelace/src/utils/navigation-tree-selection.ts
@@ -1,6 +1,31 @@
+/*
+ * See the LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
 import { type Ref } from "vue";
 import type SlTreeItem from "@shoelace-style/shoelace/dist/components/tree-item/tree-item";
 
+/**
+ * Utility class to manage the selected node in a Navigation Tree for Shoelace ds.
+ *
+ * @since 0.11
+ **/
 export class NavigationTreeSelection {
   private selectedTreeItem: SlTreeItem | undefined = undefined;
   private treeItems: Ref<Map<string, SlTreeItem>>;

--- a/ds/shoelace/src/vue/x-navigation-tree.vue
+++ b/ds/shoelace/src/vue/x-navigation-tree.vue
@@ -18,6 +18,20 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <script setup lang="ts">
+/**
+ * Navigation Tree implemented using Shoelace's Tree component.
+ * In order to use the initial component as a proper Navigation Tree for
+ * Cristal, a few changes were made:
+ *   - The list of rendered nodes is kept and updated using a mutation
+ *     observer. This lets us access them to expand and/or select them to match
+ *     the page currently opened.
+ *   - The only node selected matches the current page, or the clicked link if
+ *     the component has a custom clickAction. We want to use actual links so
+ *     that the user can click them normally (to e.g., open them in a new tab).
+ *     So the default behavior of selecting a node by clicking anywhere on the
+ *     item was disabled. Default hover effects, such as changing the cursor
+ *     on items, were also disabled.
+ */
 import { type Ref, onBeforeMount, onMounted, ref, watch } from "vue";
 import "@shoelace-style/shoelace/dist/components/tree/tree";
 import "@shoelace-style/shoelace/dist/components/tree-item/tree-item";

--- a/ds/shoelace/src/vue/x-navigation-tree.vue
+++ b/ds/shoelace/src/vue/x-navigation-tree.vue
@@ -97,8 +97,7 @@ function expandTree() {
       // If we have a custom click action, we want to use it on dynamic
       // selection.
       if (props.clickAction) {
-        treeItems.value
-          .get(expandedNodes[i])!
+        selection.getSelection()!
           .getElementsByTagName("a")[0]
           .click();
       }

--- a/ds/shoelace/src/vue/x-navigation-tree.vue
+++ b/ds/shoelace/src/vue/x-navigation-tree.vue
@@ -187,6 +187,7 @@ function lazyLoadChildren(id: string) {
 </template>
 
 <style scoped>
+/* Disable hand cursor on items. */
 :deep(sl-tree-item)::part(base) {
   cursor: default;
 }

--- a/ds/vuetify/src/vue/x-navigation-tree.vue
+++ b/ds/vuetify/src/vue/x-navigation-tree.vue
@@ -189,7 +189,7 @@ function clearSelection() {
 :deep(.v-list-item__overlay) {
   --v-hover-opacity: 0;
 }
-/* Disable hand cursor on items. */
+/* Disable hand cursor on items, since we disable the default click action. */
 :deep(.v-list-item--link) {
   cursor: default;
 }

--- a/ds/vuetify/src/vue/x-navigation-tree.vue
+++ b/ds/vuetify/src/vue/x-navigation-tree.vue
@@ -18,6 +18,17 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <script setup lang="ts">
+/**
+ * Navigation Tree implemented using Vuetify's VTreeView component.
+ * In order to use the initial component as a proper Navigation Tree for
+ * Cristal, a few changes were made:
+ *   - The only node activated matches the current page, or the clicked link if
+ *     the component has a custom clickAction. We want to use actual links so
+ *     that the user can click them normally (to e.g., open them in a new tab).
+ *     So the default behavior of activating a node by clicking anywhere on the
+ *     item was disabled. Default hover effects, such as darkening or changing
+ *     the cursor on items, were also disabled.
+ */
 import { Ref, onBeforeMount, ref, watch } from "vue";
 import { VTreeview } from "vuetify/labs/VTreeview";
 import { type PageData } from "@xwiki/cristal-api";

--- a/ds/vuetify/src/vue/x-navigation-tree.vue
+++ b/ds/vuetify/src/vue/x-navigation-tree.vue
@@ -28,9 +28,8 @@ import type {
 
 type TreeItem = {
   id: string;
-  href: undefined;
   title: string;
-  url: string;
+  href: string;
   children?: Array<TreeItem>;
   _location: string;
 };
@@ -53,9 +52,8 @@ onBeforeMount(async () => {
   for (const node of await props.treeSource.getChildNodes("")) {
     rootNodes.value.push({
       id: node.id,
-      href: undefined, // This needs to be explicit to disable mouse pointer.
       title: node.label,
-      url: node.url,
+      href: node.url,
       children: node.has_children ? [] : undefined,
       _location: node.location,
     });
@@ -104,7 +102,7 @@ async function expandTree() {
             id: node.id,
             label: node.title,
             location: node._location,
-            url: node.url,
+            url: node.href,
             has_children: node.children !== undefined,
           });
         }
@@ -119,9 +117,8 @@ async function lazyLoadChildren(item: unknown) {
   for (const child of childNodes) {
     treeItem.children?.push({
       id: child.id,
-      href: undefined,
       title: child.label,
-      url: child.url,
+      href: child.url,
       children: child.has_children ? [] : undefined,
       _location: child.location,
     });
@@ -151,7 +148,6 @@ function clearSelection() {
     :load-children="lazyLoadChildren"
     activatable
     active-strategy="independent"
-    density="compact"
     item-value="id"
     open-strategy="multiple"
     @update:activated="clearSelection"
@@ -159,26 +155,31 @@ function clearSelection() {
     <template #title="{ item }: { item: any }">
       <a
         v-if="props.clickAction"
-        :href="item.url"
+        :href="item.href"
         @click.prevent="
           activatedNodes = [item.id];
           clickAction!({
             id: item.id,
             label: item.title,
             location: item._location,
-            url: item.url,
+            url: item.href,
             has_children: item.children !== undefined,
           });
         "
         >{{ item.title }}</a
       >
-      <a v-else :href="item.url">{{ item.title }}</a>
+      <a v-else :href="item.href">{{ item.title }}</a>
     </template>
   </v-treeview>
 </template>
 
 <style scoped>
+/* Disable hover on items. */
 :deep(.v-list-item__overlay) {
   --v-hover-opacity: 0;
+}
+/* Disable hand cursor on items. */
+:deep(.v-list-item--link) {
+  cursor: default;
 }
 </style>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-244

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

Vuetify's "activation" and Shoelace's "selection" are now fully handled manually to only have a single node selected: the current page (or clicked link if a clickAction is present).
Confusing hover effects have also been disabled.

## Clarifications

~~In this PR, Vuetify's navigation tree was also made more compact to align a bit more with Shoelace's one.~~

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Test suite was run fully.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A