### PR TITLE
CRISTAL-239: Navigation tree present odd results with the Filesystem backend

### DIFF
--- a/core/navigation-tree/navigation-tree-filesystem/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-filesystem/src/components/componentsInit.ts
@@ -63,7 +63,10 @@ class FileSystemNavigationTreeSource implements NavigationTreeSource {
         const currentPageData = await this.cristalApp.getPage(id);
         navigationTree.push({
           id: id,
-          label: currentPageData ? currentPageData.name : child,
+          label:
+            currentPageData && currentPageData.name
+              ? currentPageData.name
+              : child,
           location: id,
           url: this.cristalApp.getRouter().resolve({
             name: "view",

--- a/core/navigation-tree/navigation-tree-nextcloud/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-nextcloud/src/components/componentsInit.ts
@@ -57,7 +57,10 @@ class NextcloudNavigationTreeSource implements NavigationTreeSource {
       const currentPageData = await this.cristalApp.getPage(d);
       navigationTree.push({
         id: d,
-        label: currentPageData ? currentPageData.name : d.split("/").pop()!,
+        label:
+          currentPageData && currentPageData.name
+            ? currentPageData.name
+            : d.split("/").pop()!,
         location: d,
         url: this.cristalApp.getRouter().resolve({
           name: "view",


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-239

# Changes

## Description

Add a simple fallback when a node has an empty page name.

# Executed Tests

I reproduced the issue and tested the fix manually.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A