### PR TITLE
CRISTAL-329: Creating a nested page fails to add a page with the right name

### DIFF
--- a/core/document/document-default/src/defaultDocumentService.ts
+++ b/core/document/document-default/src/defaultDocumentService.ts
@@ -82,6 +82,8 @@ function createStore(cristal: CristalApp): DocumentStoreDefinition {
       // only applied to the store at the end of an action.
       setLoading() {
         this.loading = true;
+        this.document = undefined;
+        this.error = undefined;
       },
       async update(
         documentReference: string,
@@ -150,14 +152,12 @@ export class DefaultDocumentService implements DocumentService {
   }
 
   setCurrentDocument(documentReference: string, revision?: string): void {
-    // this.store.setLoading();
     this.store.update(documentReference, true, revision);
   }
 
   refreshCurrentDocument(): void {
     const documentReference = this.store.lastDocumentReference;
     if (documentReference) {
-      // this.store.setLoading();
       this.store.update(documentReference, false, this.store.lastRevision);
     }
   }

--- a/core/model/model-reference/model-reference-xwiki/src/__tests__/defaultLocalURLSerializer.test.ts
+++ b/core/model/model-reference/model-reference-xwiki/src/__tests__/defaultLocalURLSerializer.test.ts
@@ -54,7 +54,11 @@ describe("defaultLocalURLSerializer", () => {
   it("serialize a document reference without a space", () => {
     expect(serializer.serialize(new DocumentReference("Page"))).to.eq("Page");
   });
-  it("serialize a document reference without a space", () => {
-    expect(serializer.serialize(new DocumentReference("Page"))).to.eq("Page");
+  it("serialize a document reference with an empty space", () => {
+    expect(
+      serializer.serialize(
+        new DocumentReference("Page", new SpaceReference(undefined)),
+      ),
+    ).to.eq("Page");
   });
 });

--- a/core/model/model-reference/model-reference-xwiki/src/xWikiModelReferenceSerializer.ts
+++ b/core/model/model-reference/model-reference-xwiki/src/xWikiModelReferenceSerializer.ts
@@ -54,7 +54,7 @@ export class XWikiModelReferenceSerializer implements ModelReferenceSerializer {
         const documentReference = reference as DocumentReference;
         const spaces = this.serialize(documentReference.space);
         const name = documentReference.name;
-        if (spaces === undefined) {
+        if (spaces === undefined || spaces == "") {
           return name;
         } else {
           return `${spaces}.${name}`;

--- a/core/navigation-tree/navigation-tree-api/package.json
+++ b/core/navigation-tree/navigation-tree-api/package.json
@@ -23,7 +23,8 @@
     "lint": "eslint \"./src/**/*.{ts,tsx}\" --max-warnings=0"
   },
   "dependencies": {
-    "@xwiki/cristal-api": "workspace:*"
+    "@xwiki/cristal-api": "workspace:*",
+    "@xwiki/cristal-model-api": "workspace:*"
   },
   "publishConfig": {
     "exports": {

--- a/core/navigation-tree/navigation-tree-api/src/index.ts
+++ b/core/navigation-tree/navigation-tree-api/src/index.ts
@@ -19,6 +19,7 @@
  */
 
 import type { PageData } from "@xwiki/cristal-api";
+import type { SpaceReference } from "@xwiki/cristal-model-api";
 
 /**
  * Description of a navigation tree node.
@@ -29,7 +30,7 @@ type NavigationTreeNode = {
   id: string;
   label: string;
   /** the location of the corresponding page on Cristal */
-  location: string;
+  location: SpaceReference;
   url: string;
   has_children: boolean;
 };

--- a/core/navigation-tree/navigation-tree-filesystem/package.json
+++ b/core/navigation-tree/navigation-tree-filesystem/package.json
@@ -25,6 +25,7 @@
   "dependencies": {
     "@xwiki/cristal-api": "workspace:*",
     "@xwiki/cristal-electron-storage": "workspace:*",
+    "@xwiki/cristal-model-api": "workspace:*",
     "@xwiki/cristal-navigation-tree-api": "workspace:*",
     "@xwiki/cristal-navigation-tree-default": "workspace:*",
     "inversify": "6.0.3"

--- a/core/navigation-tree/navigation-tree-filesystem/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-filesystem/src/components/componentsInit.ts
@@ -18,6 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
+import { SpaceReference } from "@xwiki/cristal-model-api";
 import { name as NavigationTreeSourceName } from "@xwiki/cristal-navigation-tree-api";
 import { getParentNodesIdFromPath } from "@xwiki/cristal-navigation-tree-default";
 import { Container, inject, injectable } from "inversify";
@@ -67,7 +68,7 @@ class FileSystemNavigationTreeSource implements NavigationTreeSource {
             currentPageData && currentPageData.name
               ? currentPageData.name
               : child,
-          location: id,
+          location: new SpaceReference(undefined, ...id.split("/")),
           url: this.cristalApp.getRouter().resolve({
             name: "view",
             params: {

--- a/core/navigation-tree/navigation-tree-github/package.json
+++ b/core/navigation-tree/navigation-tree-github/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@xwiki/cristal-api": "workspace:*",
+    "@xwiki/cristal-model-api": "workspace:*",
     "@xwiki/cristal-navigation-tree-api": "workspace:*",
     "@xwiki/cristal-navigation-tree-default": "workspace:*",
     "inversify": "6.0.3"

--- a/core/navigation-tree/navigation-tree-github/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-github/src/components/componentsInit.ts
@@ -18,6 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
+import { SpaceReference } from "@xwiki/cristal-model-api";
 import { name as NavigationTreeSourceName } from "@xwiki/cristal-navigation-tree-api";
 import { getParentNodesIdFromPath } from "@xwiki/cristal-navigation-tree-default";
 import { Container, inject, injectable } from "inversify";
@@ -70,7 +71,10 @@ class GitHubNavigationTreeSource implements NavigationTreeSource {
           navigationTree.push({
             id: treeNode.path,
             label: treeNode.name,
-            location: treeNode.path,
+            location: new SpaceReference(
+              undefined,
+              ...treeNode.path.split("/"),
+            ),
             url: this.cristalApp.getRouter().resolve({
               name: "view",
               params: {

--- a/core/navigation-tree/navigation-tree-nextcloud/package.json
+++ b/core/navigation-tree/navigation-tree-nextcloud/package.json
@@ -24,6 +24,7 @@
   },
   "dependencies": {
     "@xwiki/cristal-api": "workspace:*",
+    "@xwiki/cristal-model-api": "workspace:*",
     "@xwiki/cristal-navigation-tree-api": "workspace:*",
     "@xwiki/cristal-navigation-tree-default": "workspace:*",
     "inversify": "6.0.3"

--- a/core/navigation-tree/navigation-tree-nextcloud/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-nextcloud/src/components/componentsInit.ts
@@ -18,6 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
+import { SpaceReference } from "@xwiki/cristal-model-api";
 import { name as NavigationTreeSourceName } from "@xwiki/cristal-navigation-tree-api";
 import { getParentNodesIdFromPath } from "@xwiki/cristal-navigation-tree-default";
 import { Container, inject, injectable } from "inversify";
@@ -58,14 +59,15 @@ class NextcloudNavigationTreeSource implements NavigationTreeSource {
 
     const subdirectories = await this.getSubDirectories(currentId);
     for (const d of subdirectories) {
+      const spaces = d.split("/");
       const currentPageData = await this.cristalApp.getPage(d);
       navigationTree.push({
         id: d,
         label:
           currentPageData && currentPageData.name
             ? currentPageData.name
-            : d.split("/").pop()!,
-        location: d,
+            : spaces[spaces.length - 1],
+        location: new SpaceReference(undefined, ...spaces),
         url: this.cristalApp.getRouter().resolve({
           name: "view",
           params: {

--- a/core/navigation-tree/navigation-tree-xwiki/package.json
+++ b/core/navigation-tree/navigation-tree-xwiki/package.json
@@ -25,6 +25,9 @@
   "dependencies": {
     "@xwiki/cristal-api": "workspace:*",
     "@xwiki/cristal-authentication-api": "workspace:*",
+    "@xwiki/cristal-model-api": "workspace:*",
+    "@xwiki/cristal-model-reference-api": "workspace:*",
+    "@xwiki/cristal-model-remote-url-api": "workspace:*",
     "@xwiki/cristal-navigation-tree-api": "workspace:*",
     "inversify": "6.0.3"
   },

--- a/ds/shoelace/src/vue/x-navigation-tree.vue
+++ b/ds/shoelace/src/vue/x-navigation-tree.vue
@@ -134,7 +134,7 @@ async function onDocumentUpdate(page: PageData) {
         }
       } else {
         parents.shift();
-        if (items.value) {
+        if (items.value && items.value.length > 0) {
           await items.value[i].onDocumentUpdate(parents);
         }
         break;

--- a/ds/vuetify/package.json
+++ b/ds/vuetify/package.json
@@ -29,6 +29,7 @@
     "@xwiki/cristal-api": "workspace:*",
     "@xwiki/cristal-document-api": "workspace:*",
     "@xwiki/cristal-dsapi": "workspace:*",
+    "@xwiki/cristal-model-api": "workspace:*",
     "@xwiki/cristal-navigation-tree-api": "workspace:*",
     "inversify": "6.0.3",
     "vue": "3.5.12",

--- a/editors/tiptap/package.json
+++ b/editors/tiptap/package.json
@@ -47,6 +47,7 @@
     "@xwiki/cristal-document-api": "workspace:*",
     "@xwiki/cristal-icons": "workspace:*",
     "@xwiki/cristal-link-suggest-api": "workspace:*",
+    "@xwiki/cristal-model-reference-api": "workspace:*",
     "@xwiki/cristal-skin": "workspace:*",
     "avvvatars-vue": "1.1.0",
     "eventemitter3": "5.0.1",

--- a/editors/tiptap/src/vue/c-edit-tiptap.vue
+++ b/editors/tiptap/src/vue/c-edit-tiptap.vue
@@ -93,10 +93,10 @@ const save = async (authors: User[]) => {
       title.value,
       "html",
     );
-  documentService.notifyDocumentChange(
-    "update",
-    documentService.getCurrentDocument().value!,
-  );
+  if (!currentPage.value) {
+    documentService.setCurrentDocument(currentPageName.value);
+  }
+  documentService.notifyDocumentChange("update", currentPage.value!);
 };
 const submit = async () => {
   await editor.value?.storage.cristalCollaborationKit.autoSaver.save();
@@ -145,7 +145,7 @@ async function loadEditor(page: PageData | undefined) {
     content.value =
       page?.syntax == "markdown/1.2" ? page?.source : page?.html || "";
     title.value = page?.headlineRaw || "";
-    titlePlaceholder.value = page?.name || "";
+    titlePlaceholder.value = page?.name || currentPageName.value;
 
     const linkSuggestServiceProvider = cristal
       .getContainer()
@@ -196,7 +196,13 @@ async function loadEditor(page: PageData | undefined) {
   }
 }
 
-watch(currentPage, (page) => loadEditor(page), { immediate: true });
+watch(
+  loading,
+  (newLoading) => {
+    if (!newLoading) loadEditor(currentPage.value);
+  },
+  { immediate: true },
+);
 </script>
 
 <template>

--- a/editors/tiptap/src/vue/c-edit-tiptap.vue
+++ b/editors/tiptap/src/vue/c-edit-tiptap.vue
@@ -93,6 +93,8 @@ const save = async (authors: User[]) => {
       title.value,
       "html",
     );
+  // If this save operation just created the document, the current document
+  // will be undefined. So we update it.
   if (!currentPage.value) {
     documentService.setCurrentDocument(currentPageName.value);
   }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -968,6 +968,9 @@ importers:
       '@xwiki/cristal-api':
         specifier: workspace:*
         version: link:../../../api
+      '@xwiki/cristal-model-api':
+        specifier: workspace:*
+        version: link:../../model/model-api
 
   core/navigation-tree/navigation-tree-default:
     dependencies:
@@ -989,6 +992,9 @@ importers:
       '@xwiki/cristal-electron-storage':
         specifier: workspace:*
         version: link:../../../electron/storage
+      '@xwiki/cristal-model-api':
+        specifier: workspace:*
+        version: link:../../model/model-api
       '@xwiki/cristal-navigation-tree-api':
         specifier: workspace:*
         version: link:../navigation-tree-api
@@ -1004,6 +1010,9 @@ importers:
       '@xwiki/cristal-api':
         specifier: workspace:*
         version: link:../../../api
+      '@xwiki/cristal-model-api':
+        specifier: workspace:*
+        version: link:../../model/model-api
       '@xwiki/cristal-navigation-tree-api':
         specifier: workspace:*
         version: link:../navigation-tree-api
@@ -1019,6 +1028,9 @@ importers:
       '@xwiki/cristal-api':
         specifier: workspace:*
         version: link:../../../api
+      '@xwiki/cristal-model-api':
+        specifier: workspace:*
+        version: link:../../model/model-api
       '@xwiki/cristal-navigation-tree-api':
         specifier: workspace:*
         version: link:../navigation-tree-api
@@ -1037,6 +1049,15 @@ importers:
       '@xwiki/cristal-authentication-api':
         specifier: workspace:*
         version: link:../../authentication/authentication-api
+      '@xwiki/cristal-model-api':
+        specifier: workspace:*
+        version: link:../../model/model-api
+      '@xwiki/cristal-model-reference-api':
+        specifier: workspace:*
+        version: link:../../model/model-reference/model-reference-api
+      '@xwiki/cristal-model-remote-url-api':
+        specifier: workspace:*
+        version: link:../../model/model-remote-url/model-remote-url-api
       '@xwiki/cristal-navigation-tree-api':
         specifier: workspace:*
         version: link:../navigation-tree-api
@@ -1261,6 +1282,9 @@ importers:
       '@xwiki/cristal-dsapi':
         specifier: workspace:*
         version: link:../api
+      '@xwiki/cristal-model-api':
+        specifier: workspace:*
+        version: link:../../core/model/model-api
       '@xwiki/cristal-navigation-tree-api':
         specifier: workspace:*
         version: link:../../core/navigation-tree/navigation-tree-api
@@ -1349,6 +1373,9 @@ importers:
       '@xwiki/cristal-link-suggest-api':
         specifier: workspace:*
         version: link:../../core/link-suggest/link-suggest-api
+      '@xwiki/cristal-model-reference-api':
+        specifier: workspace:*
+        version: link:../../core/model/model-reference/model-reference-api
       '@xwiki/cristal-skin':
         specifier: workspace:*
         version: link:../../skin
@@ -1974,9 +2001,15 @@ importers:
       '@xwiki/cristal-info-actions-ui':
         specifier: workspace:*
         version: link:../core/info-actions/info-actions-ui
+      '@xwiki/cristal-model-api':
+        specifier: workspace:*
+        version: link:../core/model/model-api
       '@xwiki/cristal-model-click-listener':
         specifier: workspace:*
         version: link:../core/model/model-click-listener
+      '@xwiki/cristal-model-reference-api':
+        specifier: workspace:*
+        version: link:../core/model/model-reference/model-reference-api
       '@xwiki/cristal-navigation-tree-api':
         specifier: workspace:*
         version: link:../core/navigation-tree/navigation-tree-api

--- a/skin/package.json
+++ b/skin/package.json
@@ -36,6 +36,8 @@
     "@xwiki/cristal-icons": "workspace:*",
     "@xwiki/cristal-info-actions-api": "workspace:*",
     "@xwiki/cristal-info-actions-ui": "workspace:*",
+    "@xwiki/cristal-model-api": "workspace:*",
+    "@xwiki/cristal-model-reference-api": "workspace:*",
     "@xwiki/cristal-model-click-listener": "workspace:*",
     "@xwiki/cristal-navigation-tree-api": "workspace:*",
     "@xwiki/cristal-page-actions-ui": "workspace:*",

--- a/skin/src/vue/c-page-creation-menu.vue
+++ b/skin/src/vue/c-page-creation-menu.vue
@@ -55,7 +55,7 @@ function updateCurrentPage() {
 }
 
 function createPage() {
-  let newDocumentReference = new DocumentReference(
+  const newDocumentReference = new DocumentReference(
     name.value,
     locationReference!,
   );

--- a/skin/src/vue/c-page-creation-menu.vue
+++ b/skin/src/vue/c-page-creation-menu.vue
@@ -19,23 +19,35 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 -->
 <script setup lang="ts">
 import { CIcon } from "@xwiki/cristal-icons";
+import { DocumentReference, SpaceReference } from "@xwiki/cristal-model-api";
 import { defineProps, inject, ref } from "vue";
 import type { CristalApp, PageData } from "@xwiki/cristal-api";
+import type {
+  ModelReferenceSerializer,
+  ModelReferenceSerializerProvider,
+} from "@xwiki/cristal-model-reference-api";
 import type { NavigationTreeNode } from "@xwiki/cristal-navigation-tree-api";
 import type { Ref } from "vue";
 
 const cristal: CristalApp = inject<CristalApp>("cristal")!;
 
+const referenceSerializer: ModelReferenceSerializer = cristal
+  .getContainer()
+  .get<ModelReferenceSerializerProvider>("ModelReferenceSerializerProvider")
+  .get()!;
+
 const dialogOpen: Ref<boolean> = ref(false);
 const name: Ref<string> = ref("");
 const location: Ref<string> = ref("");
+var locationReference: SpaceReference | undefined = undefined;
 
 defineProps<{
   currentPage: PageData;
 }>();
 
 function treeNodeClickAction(node: NavigationTreeNode) {
-  location.value = node.location;
+  locationReference = node.location;
+  location.value = referenceSerializer.serialize(locationReference)!;
 }
 
 function updateCurrentPage() {
@@ -43,18 +55,15 @@ function updateCurrentPage() {
 }
 
 function createPage() {
-  var newPage = "";
+  let newDocumentReference = new DocumentReference(
+    name.value,
+    locationReference!,
+  );
 
-  // TODO: Use a page resolver instead when CRISTAL-234 is fixed.
-  const pageResourceSeparator =
-    cristal.getWikiConfig().getType() == "XWiki" ? "." : "/";
-
-  if (location.value) {
-    newPage += location.value + pageResourceSeparator;
-  }
-  newPage += name.value;
-
-  cristal.setCurrentPage(newPage, "edit");
+  cristal.setCurrentPage(
+    referenceSerializer.serialize(newDocumentReference)!,
+    "edit",
+  );
 
   dialogOpen.value = false;
 }

--- a/sources/xwiki/mock-server/src/index.ts
+++ b/sources/xwiki/mock-server/src/index.ts
@@ -56,28 +56,53 @@ ${revision ? "Revision " + revision : ""}
 }
 
 app.get("/xwiki/rest/cristal/page", (req: Request, res: Response) => {
-  const page: string = (req.query.page as string) || "Main.WebHome";
-  const revision: string | undefined =
-    (req.query.revision as string) || undefined;
-  const offline = page === "Main.Offline";
   res.appendHeader("Access-Control-Allow-Origin", "*");
 
-  const text = `= Welcome to ${page} =
+  const id: string = req.query.page as string;
+  let page: string = "";
+  let name: string = "";
+  let revision: string | undefined = undefined;
+  let text: string = "";
+  let html: string = "";
+
+  switch (id) {
+    case "Main.WebHome":
+      page = "Main.WebHome";
+      name = "WebHome";
+      revision = (req.query.revision as string) || undefined;
+      text = `= Welcome to ${page} =
 
 XWiki is the best tool to organize your knowledge.
 
 [[XWiki Syntax>>Page2.WebHome]]
 ${revision ? "Revision " + revision : ""}
 }`;
-  const html = getHtml(page, revision, {
-    offline,
-  });
+      html = getHtml(page, revision, { offline: false });
+      break;
+
+    case "Main.Offline":
+      page = "Main.Offline";
+      name = "Offline";
+      html = getHtml(page, revision, { offline: true });
+      break;
+
+    case "Main.NewPage.WebHome":
+      name = "NewPage";
+      break;
+
+    default:
+      page = id;
+      name = "WebHome";
+      html = getHtml(page, revision, { offline: false });
+  }
+
   res.json({
     "@context": "https://schema.org",
     "@type": "CreativeWork",
-    identifier: page,
-    name: "WebHome",
+    identifier: id,
+    name: name,
     headline: page,
+    headlineRaw: page,
     creator: page,
     encodingFormat: "xwiki/2.1",
     text: text,
@@ -185,6 +210,13 @@ app.get("/xwiki/bin/get", (req: Request, res: Response) => {
             children: true,
             data: { type: "document" },
             a_attr: { href: "/xwiki/bin/view/Deep1/" },
+          },
+          {
+            id: "document:xwiki:Main.WebHome",
+            text: "Cristal Wiki",
+            children: false,
+            data: { type: "document" },
+            a_attr: { href: "/xwiki/bin/view/Main/" },
           },
         ]);
         break;

--- a/web/e2e/main-page.spec.ts
+++ b/web/e2e/main-page.spec.ts
@@ -23,6 +23,7 @@ import { DesignSystem } from "./DesignSystem";
 import { BreadcrumbPageObject } from "./pageObjects/Breadcrumb";
 import { HistoryExtraTabPageObject } from "./pageObjects/HistoryExtraTab";
 import { NavigationTreePageObject } from "./pageObjects/NavigationTree";
+import { SidebarPageObject } from "./pageObjects/Sidebar";
 
 test.afterEach(async ({ page }, testInfo) => {
   if (testInfo.status !== testInfo.expectedStatus) {
@@ -109,14 +110,10 @@ configs.forEach(
       );
     });
 
-    test(`[${name}] has navigation tree`, async ({ page, isMobile }) => {
+    test(`[${name}] has navigation tree`, async ({ page }) => {
       await page.goto(localDefaultPage);
 
-      if (isMobile) {
-        const openSidebar = page.locator(".open-sidebar");
-        await openSidebar.nth(0).click();
-      }
-
+      await new SidebarPageObject(page).openSidebar();
       const navigationTreeNodes = await new NavigationTreePageObject(
         page,
         designSystem,
@@ -177,14 +174,10 @@ configs.forEach(
       await expect(page.locator("#xwikicontent")).toContainText("Revision 2.1");
     });
 
-    test(`[${name}] has working editor on new page`, async ({ page, isMobile }) => {
+    test(`[${name}] has working editor on new page`, async ({ page }) => {
       await page.goto(localDefaultPage);
 
-      if (isMobile) {
-        const openSidebar = page.locator(".open-sidebar");
-        await openSidebar.nth(0).click();
-      }
-
+      await new SidebarPageObject(page).openSidebar();
       await page.locator("#sidebar #new-page-button").nth(0).click();
 
       const newPageDialogButton = page.getByRole('button', { name: 'Create' }).nth(0);

--- a/web/e2e/main-page.spec.ts
+++ b/web/e2e/main-page.spec.ts
@@ -122,7 +122,7 @@ configs.forEach(
         designSystem,
       ).findItems();
 
-      expect(navigationTreeNodes.length).toEqual(3);
+      expect(navigationTreeNodes.length).toEqual(4);
       await expect(navigationTreeNodes[0].getText()).toContainText("Help");
       expect(await navigationTreeNodes[0].getLink()).toEqual(
         "#/Help.WebHome/view",
@@ -136,6 +136,12 @@ configs.forEach(
       );
       expect(await navigationTreeNodes[2].getLink()).toEqual(
         "#/Deep1.WebHome/view",
+      );
+      await expect(navigationTreeNodes[3].getText()).toContainText(
+        "Cristal Wiki",
+      );
+      expect(await navigationTreeNodes[3].getLink()).toEqual(
+        "#/Main.WebHome/view",
       );
 
       await navigationTreeNodes[2].expand();
@@ -169,6 +175,33 @@ configs.forEach(
       // We open a revision and check that the content updated.
       await (await revisions[1].getLink()).click();
       await expect(page.locator("#xwikicontent")).toContainText("Revision 2.1");
+    });
+
+    test(`[${name}] has working editor on new page`, async ({ page, isMobile }) => {
+      await page.goto(localDefaultPage);
+
+      if (isMobile) {
+        const openSidebar = page.locator(".open-sidebar");
+        await openSidebar.nth(0).click();
+      }
+
+      await page.locator("#sidebar #new-page-button").nth(0).click();
+
+      const newPageDialogButton = page.getByRole('button', { name: 'Create' }).nth(0);
+
+      // The button can end up unclickable sometimes, due to the speed of the test.
+      // This ensures that it still gets clicked no matter what.
+      await expect(newPageDialogButton).toBeEnabled();
+      await newPageDialogButton.dispatchEvent("click");
+
+      const editorHeader = page.locator(".edit-wrapper .doc-header input").nth(0);
+      const editorContent = page.locator(".edit-wrapper .doc-content p").nth(0);
+      expect(await editorHeader.getAttribute("placeholder")).toEqual("NewPage");
+      expect(editorHeader).toBeEmpty();
+      expect(await editorContent.getAttribute("data-placeholder")).toEqual(
+        "Type '/' to show the available actions"
+      );
+      expect(editorContent).toBeEmpty();
     });
 
     if (offlineDefaultPage) {

--- a/web/e2e/pageObjects/Sidebar.ts
+++ b/web/e2e/pageObjects/Sidebar.ts
@@ -23,6 +23,7 @@ import type { Locator, Page } from "@playwright/test";
 
 /**
  * Page object to interact with the sidebar.
+ * @since 0.13
  */
 export class SidebarPageObject {
   private sidebarLocator: Locator;

--- a/web/e2e/pageObjects/Sidebar.ts
+++ b/web/e2e/pageObjects/Sidebar.ts
@@ -1,0 +1,64 @@
+/*
+ * See the LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import { expect } from "@playwright/test";
+import type { Locator, Page } from "@playwright/test";
+
+/**
+ * Page object to interact with the sidebar.
+ */
+export class SidebarPageObject {
+  private sidebarLocator: Locator;
+
+  constructor(
+    private readonly page: Page,
+  ) {
+    this.sidebarLocator = this.page.locator("#sidebar");
+  }
+
+  async openSidebar(): Promise<void> {
+    await expect(this.sidebarLocator.locator("..")).toBeVisible();
+    if (!await this.sidebarLocator.isVisible()) {
+      const openSidebar = this.page.locator(".open-sidebar");
+      await openSidebar.nth(0).click();
+    }
+    await expect(this.sidebarLocator).toBeVisible();
+  }
+
+  async hideSidebar(): Promise<void> {
+    await expect(this.sidebarLocator.locator("..")).toBeVisible();
+    if (!await this.sidebarLocator.isHidden()) {
+      const hideSidebar = this.page.locator(".hide-sidebar:visible").or(
+        this.page.locator(".close-sidebar:visible")
+      );
+      await hideSidebar.nth(0).click();
+    }
+    await expect(this.sidebarLocator).toBeHidden();
+  }
+
+  async pinSidebar(): Promise<void> {
+    await this.openSidebar();
+    const pinSidebar = this.page.locator(".pin-sidebar");
+    if (await pinSidebar.isVisible()) {
+      await pinSidebar.nth(0).click();
+    }
+    await expect(pinSidebar).toBeHidden();
+  }
+}

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -101,5 +101,10 @@ export default defineConfig({
       url: "http://127.0.0.1:15680",
       reuseExistingServer: !process.env.CI,
     },
+    {
+      command: "pnpm run --prefix .. dev:cristal-realtime",
+      port: 15681,
+      reuseExistingServer: !process.env.CI,
+    },
   ],
 });


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-329

# Changes

## Description

* This PR fixes an issue with realtime editor that was fetching the wrong page on creation.
* Page creation was also improved to use SpaceReferences instead of manually crafting the new reference.
* While reviewing this issue, I detected a few edge cases on the navigation tree I did not catch before. It should now be more reliable.
* This also adds a small UI test that checks realtime editor opens properly, with the right data, on page creation.

## Clarifications

Fixing the issue with the realtime editor led to a new one: when the editor first saves a page that did not exist previously, the DocumentService is not updated with the currently edited page. This was not reproducible with the XWiki backend since the server always returns a document, even if the page doesn't exist yet.
So the editor now updates the current document after a save.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Reproduction steps were executed, and the test suite was executed locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A