### PR TITLE
CRISTAL-300: CSS for the table displayer

### DIFF
--- a/core/attachments/attachments-ui/src/vue/AttachmentsTab.vue
+++ b/core/attachments/attachments-ui/src/vue/AttachmentsTab.vue
@@ -73,14 +73,23 @@ async function upload(files: File[]) {
 </script>
 
 <template>
-  <AttachmentUploadForm
-    ref="attachmentUpload"
-    :is-uploading="isUploading"
-    @files-selected="upload"
-  ></AttachmentUploadForm>
-  <AttachmentsTable
-    :attachments="attachments"
-    :error-message="errorMessage"
-    :is-loading="isLoading"
-  />
+  <div class="attachments">
+    <AttachmentUploadForm
+      ref="attachmentUpload"
+      :is-uploading="isUploading"
+      @files-selected="upload"
+    ></AttachmentUploadForm>
+    <AttachmentsTable
+      :attachments="attachments"
+      :error-message="errorMessage"
+      :is-loading="isLoading"
+    />
+  </div>
 </template>
+<style scoped>
+.attachments {
+  display:flex;
+  flex-flow: column;
+  gap:16px;
+}
+</style>

--- a/core/attachments/attachments-ui/src/vue/AttachmentsTable.vue
+++ b/core/attachments/attachments-ui/src/vue/AttachmentsTable.vue
@@ -42,7 +42,7 @@ const hasAuthor = computed(() => {
   <span v-else-if="attachments.length == 0">
     {{ t("attachments.tab.noAttachments") }}
   </span>
-  <table v-else>
+  <table v-else class="mobile-transform">
     <thead>
       <tr>
         <th>{{ t("attachments.tab.table.header.name") }}</th>
@@ -55,25 +55,22 @@ const hasAuthor = computed(() => {
     <tbody>
       <tr v-for="attachment in attachments" :key="attachment.id">
         <td>
+          <span class="mobile-column-name">{{ t("attachments.tab.table.header.name") }}</span>
           <a
             :href="attachment.href"
             @click="attachmentPreview(attachment.href, $event)"
             >{{ attachment.name }}</a
           >
         </td>
-        <td>{{ attachment.mimetype }}</td>
-        <td><file-size :size="attachment.size"></file-size></td>
-        <td><date :date="attachment.date"></date></td>
+        <td>
+          <span class="mobile-column-name">{{ t("attachments.tab.table.header.mimetype") }}</span>{{ attachment.mimetype }}</td>
+        <td><span class="mobile-column-name">{{ t("attachments.tab.table.header.size") }}</span><file-size :size="attachment.size"></file-size></td>
+        <td><span class="mobile-column-name">{{ t("attachments.tab.table.header.date") }}</span><date :date="attachment.date"></date></td>
         <td v-if="hasAuthor">
+          <span class="mobile-column-name">{{ t("attachments.tab.table.header.author") }}</span>
           <user v-if="attachment.author" :user="attachment.author"></user>
         </td>
       </tr>
     </tbody>
   </table>
 </template>
-
-<style>
-tbody td {
-  padding: 3px;
-}
-</style>

--- a/ds/shoelace/src/vue/css/style.css
+++ b/ds/shoelace/src/vue/css/style.css
@@ -83,7 +83,6 @@
   --cr-focus-ring: var(--sl-focus-ring-style) var(--sl-focus-ring-width) var(--sl-focus-ring-color);
   --cr-focus-ring-offset: 1px;
 
-
   /*
  * Color Primitives
  */

--- a/ds/shoelace/src/vue/css/style.css
+++ b/ds/shoelace/src/vue/css/style.css
@@ -33,6 +33,8 @@
   --cr-sizes-collapsed-main-sidebar-width: 32px; /*The width of the bar that gets shown containing the menu button to reopen the standard main main sidebar*/
   --cr-base-font-size: 16px;
   --cr-base-text-color: var(--cr-color-gray-950);
+  --cr-base-link-color: var(--cr-color-blue-600);
+  --cr-base-visited-link-color: var(--cr-color-blue-800);
 
   /*
    * Typography
@@ -81,6 +83,244 @@
   --cr-focus-ring: var(--sl-focus-ring-style) var(--sl-focus-ring-width) var(--sl-focus-ring-color);
   --cr-focus-ring-offset: 1px;
 
+
+  /*
+ * Color Primitives
+ */
+
+  /* Gray */
+  --cr-color-gray-50: var(--sl-color-gray-50);
+  --cr-color-gray-100: var(--sl-color-gray-100  );
+  --cr-color-gray-200: var(--sl-color-gray-200  );
+  --cr-color-gray-300: var(--sl-color-gray-300  );
+  --cr-color-gray-400: var(--sl-color-gray-400  );
+  --cr-color-gray-500: var(--sl-color-gray-500  );
+  --cr-color-gray-600: var(--sl-color-gray-600  );
+  --cr-color-gray-700: var(--sl-color-gray-700  );
+  --cr-color-gray-800: var(--sl-color-gray-800  );
+  --cr-color-gray-900: var(--sl-color-gray-900  );
+  --cr-color-gray-950: var(--sl-color-gray-950  );
+
+  /* Red */
+  --cr-color-red-50: var(--sl-color-red-50);
+  --cr-color-red-100: var(--sl-color-red-100);
+  --cr-color-red-200: var(--sl-color-red-200);
+  --cr-color-red-300: var(--sl-color-red-300);
+  --cr-color-red-400: var(--sl-color-red-400);
+  --cr-color-red-500: var(--sl-color-red-500);
+  --cr-color-red-600: var(--sl-color-red-600);
+  --cr-color-red-700: var(--sl-color-red-700);
+  --cr-color-red-800: var(--sl-color-red-800);
+  --cr-color-red-900: var(--sl-color-red-900);
+  --cr-color-red-950: var(--sl-color-red-950);
+
+  /* Orange */
+  --cr-color-orange-50: var(--sl-color-orange-5);
+  --cr-color-orange-10: var(--sl-color-orange-10);
+  --cr-color-orange-20: var(--sl-color-orange-20);
+  --cr-color-orange-30: var(--sl-color-orange-30);
+  --cr-color-orange-40: var(--sl-color-orange-40);
+  --cr-color-orange-50: var(--sl-color-orange-50);
+  --cr-color-orange-60: var(--sl-color-orange-60);
+  --cr-color-orange-70: var(--sl-color-orange-70);
+  --cr-color-orange-80: var(--sl-color-orange-80);
+  --cr-color-orange-90: var(--sl-color-orange-90);
+  --cr-color-orange-95: var(--sl-color-orange-90);
+
+  /* Amber */
+  --cr-color-amber-50: var(--sl-color-amber-50);
+  --cr-color-amber-100: var(--sl-color-amber-10);
+  --cr-color-amber-200: var(--sl-color-amber-20);
+  --cr-color-amber-300: var(--sl-color-amber-30);
+  --cr-color-amber-400: var(--sl-color-amber-40);
+  --cr-color-amber-500: var(--sl-color-amber-50);
+  --cr-color-amber-600: var(--sl-color-amber-60);
+  --cr-color-amber-700: var(--sl-color-amber-70);
+  --cr-color-amber-800: var(--sl-color-amber-80);
+  --cr-color-amber-900: var(--sl-color-amber-90);
+  --cr-color-amber-950: var(--sl-color-amber-95);
+
+  /* Yellow */
+  --cr-color-yellow-50: var(--sl-color-yellow-5);
+  --cr-color-yellow-10: var(--sl-color-yellow-10);
+  --cr-color-yellow-20: var(--sl-color-yellow-20);
+  --cr-color-yellow-30: var(--sl-color-yellow-30);
+  --cr-color-yellow-40: var(--sl-color-yellow-40);
+  --cr-color-yellow-50: var(--sl-color-yellow-50);
+  --cr-color-yellow-60: var(--sl-color-yellow-60);
+  --cr-color-yellow-70: var(--sl-color-yellow-70);
+  --cr-color-yellow-80: var(--sl-color-yellow-80);
+  --cr-color-yellow-90: var(--sl-color-yellow-90);
+  --cr-color-yellow-95: var(--sl-color-yellow-90);
+
+  /* Lime */
+  --cr-color-lime-50: var(--sl-color-lime-50);
+  --cr-color-lime-100: var(--sl-color-lime-100  );
+  --cr-color-lime-200: var(--sl-color-lime-200  );
+  --cr-color-lime-300: var(--sl-color-lime-300  );
+  --cr-color-lime-400: var(--sl-color-lime-400  );
+  --cr-color-lime-500: var(--sl-color-lime-500  );
+  --cr-color-lime-600: var(--sl-color-lime-600  );
+  --cr-color-lime-700: var(--sl-color-lime-700  );
+  --cr-color-lime-800: var(--sl-color-lime-800  );
+  --cr-color-lime-900: var(--sl-color-lime-900  );
+  --cr-color-lime-950: var(--sl-color-lime-950  );
+
+  /* Green */
+  --cr-color-green-50: var(--sl-color-green-50  );
+  --cr-color-green-100: var(--sl-color-green-10);
+  --cr-color-green-200: var(--sl-color-green-20);
+  --cr-color-green-300: var(--sl-color-green-30);
+  --cr-color-green-400: var(--sl-color-green-40);
+  --cr-color-green-500: var(--sl-color-green-50);
+  --cr-color-green-600: var(--sl-color-green-60);
+  --cr-color-green-700: var(--sl-color-green-70);
+  --cr-color-green-800: var(--sl-color-green-80);
+  --cr-color-green-900: var(--sl-color-green-90);
+  --cr-color-green-950: var(--sl-color-green-95);
+
+  /* Emerald */
+  --cr-color-emerald-5: var(--sl-color-emerald-0);
+  --cr-color-emerald-1: var(--sl-color-emerald-00);
+  --cr-color-emerald-2: var(--sl-color-emerald-00);
+  --cr-color-emerald-3: var(--sl-color-emerald-00);
+  --cr-color-emerald-4: var(--sl-color-emerald-00);
+  --cr-color-emerald-5: var(--sl-color-emerald-00);
+  --cr-color-emerald-6: var(--sl-color-emerald-00);
+  --cr-color-emerald-7: var(--sl-color-emerald-00);
+  --cr-color-emerald-8: var(--sl-color-emerald-00);
+  --cr-color-emerald-9: var(--sl-color-emerald-00);
+  --cr-color-emerald-9: var(--sl-color-emerald-50);
+
+  /* Teal */
+  --cr-color-teal-50: var(--sl-color-teal-50);
+  --cr-color-teal-100: var(--sl-color-teal-100  );
+  --cr-color-teal-200: var(--sl-color-teal-200  );
+  --cr-color-teal-300: var(--sl-color-teal-300  );
+  --cr-color-teal-400: var(--sl-color-teal-400  );
+  --cr-color-teal-500: var(--sl-color-teal-500  );
+  --cr-color-teal-600: var(--sl-color-teal-600  );
+  --cr-color-teal-700: var(--sl-color-teal-700  );
+  --cr-color-teal-800: var(--sl-color-teal-800  );
+  --cr-color-teal-900: var(--sl-color-teal-900  );
+  --cr-color-teal-950: var(--sl-color-teal-950  );
+
+  /* Cyan */
+  --cr-color-cyan-50: var(--sl-color-cyan-50);
+  --cr-color-cyan-100: var(--sl-color-cyan-100  );
+  --cr-color-cyan-200: var(--sl-color-cyan-200  );
+  --cr-color-cyan-300: var(--sl-color-cyan-300  );
+  --cr-color-cyan-400: var(--sl-color-cyan-400  );
+  --cr-color-cyan-500: var(--sl-color-cyan-500  );
+  --cr-color-cyan-600: var(--sl-color-cyan-600  );
+  --cr-color-cyan-700: var(--sl-color-cyan-700  );
+  --cr-color-cyan-800: var(--sl-color-cyan-800  );
+  --cr-color-cyan-900: var(--sl-color-cyan-900  );
+  --cr-color-cyan-950: var(--sl-color-cyan-950  );
+
+  /* Sky */
+  --cr-color-sky-50: var(--cr-color-sky-50);
+  --cr-color-sky-100: var(--cr-color-sky-100);
+  --cr-color-sky-200: var(--cr-color-sky-200);
+  --cr-color-sky-300: var(--cr-color-sky-300);
+  --cr-color-sky-400: var(--cr-color-sky-400);
+  --cr-color-sky-500: var(--cr-color-sky-500);
+  --cr-color-sky-600: var(--cr-color-sky-600);
+  --cr-color-sky-700: var(--cr-color-sky-700);
+  --cr-color-sky-800: var(--cr-color-sky-800);
+  --cr-color-sky-900: var(--cr-color-sky-900);
+  --cr-color-sky-950: var(--cr-color-sky-950);
+
+  /* Blue */
+  --cr-color-blue-50: var(--sl-color-blue-50);
+  --cr-color-blue-100: var(--sl-color-blue-100  );
+  --cr-color-blue-200: var(--sl-color-blue-200  );
+  --cr-color-blue-300: var(--sl-color-blue-300  );
+  --cr-color-blue-400: var(--sl-color-blue-400  );
+  --cr-color-blue-500: var(--sl-color-blue-500  );
+  --cr-color-blue-600: var(--sl-color-blue-600  );
+  --cr-color-blue-700: var(--sl-color-blue-700  );
+  --cr-color-blue-800: var(--sl-color-blue-800  );
+  --cr-color-blue-900: var(--sl-color-blue-900  );
+  --cr-color-blue-950: var(--sl-color-blue-950  );
+
+  /* Indigo */
+  --cr-color-indigo-50: var(--sl-color-indigo-5);
+  --cr-color-indigo-10: var(--sl-color-indigo-10);
+  --cr-color-indigo-20: var(--sl-color-indigo-20);
+  --cr-color-indigo-30: var(--sl-color-indigo-30);
+  --cr-color-indigo-40: var(--sl-color-indigo-40);
+  --cr-color-indigo-50: var(--sl-color-indigo-50);
+  --cr-color-indigo-60: var(--sl-color-indigo-60);
+  --cr-color-indigo-70: var(--sl-color-indigo-70);
+  --cr-color-indigo-80: var(--sl-color-indigo-80);
+  --cr-color-indigo-90: var(--sl-color-indigo-90);
+  --cr-color-indigo-95: var(--sl-color-indigo-90);
+
+  /* Violet */
+  --cr-color-violet-50: var(--sl-color-violet-5);
+  --cr-color-violet-10: var(--sl-color-violet-10);
+  --cr-color-violet-20: var(--sl-color-violet-20);
+  --cr-color-violet-30: var(--sl-color-violet-30);
+  --cr-color-violet-40: var(--sl-color-violet-40);
+  --cr-color-violet-50: var(--sl-color-violet-50);
+  --cr-color-violet-60: var(--sl-color-violet-60);
+  --cr-color-violet-70: var(--sl-color-violet-70);
+  --cr-color-violet-80: var(--sl-color-violet-80);
+  --cr-color-violet-90: var(--sl-color-violet-90);
+  --cr-color-violet-95: var(--sl-color-violet-90);
+
+  /* Purple */
+  --cr-color-purple-50: var(--sl-color-purple-5);
+  --cr-color-purple-10: var(--sl-color-purple-10);
+  --cr-color-purple-20: var(--sl-color-purple-20);
+  --cr-color-purple-30: var(--sl-color-purple-30);
+  --cr-color-purple-40: var(--sl-color-purple-40);
+  --cr-color-purple-50: var(--sl-color-purple-50);
+  --cr-color-purple-60: var(--sl-color-purple-60);
+  --cr-color-purple-70: var(--sl-color-purple-70);
+  --cr-color-purple-80: var(--sl-color-purple-80);
+  --cr-color-purple-90: var(--sl-color-purple-90);
+  --cr-color-purple-95: var(--sl-color-purple-90);
+
+  /* Fuchsia */
+  --cr-color-fuchsia-5: var(--sl-color-fuchsia-0);
+  --cr-color-fuchsia-1: var(--sl-color-fuchsia-00);
+  --cr-color-fuchsia-2: var(--sl-color-fuchsia-00);
+  --cr-color-fuchsia-3: var(--sl-color-fuchsia-00);
+  --cr-color-fuchsia-4: var(--sl-color-fuchsia-00);
+  --cr-color-fuchsia-5: var(--sl-color-fuchsia-00);
+  --cr-color-fuchsia-6: var(--sl-color-fuchsia-00);
+  --cr-color-fuchsia-7: var(--sl-color-fuchsia-00);
+  --cr-color-fuchsia-8: var(--sl-color-fuchsia-00);
+  --cr-color-fuchsia-9: var(--sl-color-fuchsia-00);
+  --cr-color-fuchsia-9: var(--sl-color-fuchsia-50);
+
+  /* Pink */
+  --cr-color-pink-50: var(--sl-color-pink-50);
+  --cr-color-pink-100: var(--sl-color-pink-100  );
+  --cr-color-pink-200: var(--sl-color-pink-200  );
+  --cr-color-pink-300: var(--sl-color-pink-300  );
+  --cr-color-pink-400: var(--sl-color-pink-400  );
+  --cr-color-pink-500: var(--sl-color-pink-500  );
+  --cr-color-pink-600: var(--sl-color-pink-600  );
+  --cr-color-pink-700: var(--sl-color-pink-700  );
+  --cr-color-pink-800: var(--sl-color-pink-800  );
+  --cr-color-pink-900: var(--sl-color-pink-900  );
+  --cr-color-pink-950: var(--sl-color-pink-950  );
+
+  /* Rose */
+  --cr-color-rose-50: var(--sl-color-rose-50 );
+  --cr-color-rose-100: var(--sl-color-rose-100  );
+  --cr-color-rose-200: var(--sl-color-rose-200  );
+  --cr-color-rose-300: var(--sl-color-rose-300  );
+  --cr-color-rose-400: var(--sl-color-rose-400  );
+  --cr-color-rose-500: var(--sl-color-rose-500  );
+  --cr-color-rose-600: var(--sl-color-rose-600  );
+  --cr-color-rose-700: var(--sl-color-rose-700  );
+  --cr-color-rose-800: var(--sl-color-rose-800  );
+  --cr-color-rose-900: var(--sl-color-rose-900  );
+  --cr-color-rose-950: var(--sl-color-rose-950  );
 
   /*Colors*/
 

--- a/ds/shoelace/src/vue/css/style.css
+++ b/ds/shoelace/src/vue/css/style.css
@@ -33,8 +33,8 @@
   --cr-sizes-collapsed-main-sidebar-width: 32px; /*The width of the bar that gets shown containing the menu button to reopen the standard main main sidebar*/
   --cr-base-font-size: 16px;
   --cr-base-text-color: var(--cr-color-gray-950);
-  --cr-base-link-color: var(--cr-color-blue-600);
-  --cr-base-visited-link-color: var(--cr-color-blue-800);
+  --cr-base-link-color: var(--cr-base-text-color);
+  --cr-base-visited-link-color: var(--cr-base-text-color);
 
   /*
    * Typography

--- a/ds/vuetify/src/vue/css/style.css
+++ b/ds/vuetify/src/vue/css/style.css
@@ -32,6 +32,8 @@
   --cr-sizes-collapsed-main-sidebar-width: 32px; /*The width of the bar that gets shown containing the menu button to reopen the standard main main sidebar*/
   --cr-base-font-size: 16px;
   --cr-base-text-color: var(--cr-color-gray-950);
+  --cr-base-link-color: var(--cr-base-text-color);
+  --cr-base-visited-link-color: var(--cr-base-text-color);
 
 
   /*

--- a/editors/tiptap/src/vue/c-edit-tiptap.vue
+++ b/editors/tiptap/src/vue/c-edit-tiptap.vue
@@ -341,6 +341,11 @@ TODO: should be moved to a css specific to the empty line placeholder plugin.
   justify-self: center;
 }
 
+:deep(.editor table td),
+:deep(.editor table th) {
+  border: 1px solid var(--cr-color-neutral-300);
+}
+
 /*
  * Collaboration styles.
  *

--- a/skin/src/vue/c-content.vue
+++ b/skin/src/vue/c-content.vue
@@ -278,39 +278,6 @@ onUpdated(() => {
 :global(.doc-header-inner) {
   padding: 0;
 }
-:global(.doc-content table) {
-  max-width: 100%;
-  width: 100%;
-  border: none;
-  border-collapse: collapse;
-  color: inherit;
-  margin-bottom: var(--cr-spacing-small);
-}
-
-:global(.doc-content table tr) {
-  border-bottom: solid 1px var(--cr-input-border-color);
-}
-
-:global(.doc-content table th) {
-  font-weight: var(--cr-font-weight-bold);
-  text-align: start;
-}
-
-:global(.doc-content table td),
-:global(.doc-content table th) {
-  line-height: var(--cr-line-height-normal);
-  padding: 1rem 1rem;
-}
-
-:global(.doc-content table th p:first-child),
-:global(.doc-content table td p:first-child) {
-  margin-top: 0;
-}
-
-:global(.doc-content table th p:last-child),
-:global(.doc-content table td p:last-child) {
-  margin-bottom: 0;
-}
 
 /*---*/
 

--- a/skin/src/vue/c-view.vue
+++ b/skin/src/vue/c-view.vue
@@ -266,7 +266,7 @@ TODO: these rules about opening and closing the sidebar should be better organiz
 /*TABLE*/
 :deep(table) {
   border-collapse: collapse;
-  overflow-x:auto;
+  overflow-x: auto;
   font-size: var(--cr-font-size-small);
   line-height: var(--cr-line-height-dense);
   & th,
@@ -296,7 +296,7 @@ TODO: these rules about opening and closing the sidebar should be better organiz
         border-bottom: 0;
       }
       & .mobile-column-name {
-        display: none
+        display: none;
       }
     }
   }
@@ -343,8 +343,8 @@ TODO: Discuss and move them to a more appropriate place
   .resize-handle {
     display: none;
   }
-  :deep(table.mobile-transform){
-    & thead{
+  :deep(table.mobile-transform) {
+    & thead {
       & th {
         display: none;
       }
@@ -364,7 +364,6 @@ TODO: Discuss and move them to a more appropriate place
         }
       }
     }
-    
   }
 }
 </style>

--- a/skin/src/vue/c-view.vue
+++ b/skin/src/vue/c-view.vue
@@ -245,6 +245,41 @@ TODO: these rules about opening and closing the sidebar should be better organiz
   display: block;
 }
 
+/*TABLE*/
+:deep(table) {
+  border-collapse: collapse;
+  width: 100%;
+  font-size: var(--cr-font-size-small);
+  & th, td {
+    text-align: start;
+  }
+  & th {
+    background-color: var(--cr-color-neutral-100);
+    padding: var(--cr-spacing-x-small) ;
+    font-weight: var(--cr-font-weight-semibold);
+    
+
+    &:first-child {
+      border-top-left-radius: var(--cr-border-radius-large);
+    }
+    &:last-child {
+      border-top-right-radius: var(--cr-border-radius-large);
+    }
+  }
+  & td {
+    padding: var(--cr-spacing-small) var(--cr-spacing-x-small);
+  }
+  tbody {
+    & tr {
+      border-bottom: 1px solid var(--cr-color-neutral-200);
+
+      &:last-child {
+        border-bottom: 0
+      }
+    }
+  }
+}
+
 /*
 WIKI STYLES
 TODO: Discuss and move them to a more appropriate place

--- a/skin/src/vue/c-view.vue
+++ b/skin/src/vue/c-view.vue
@@ -245,11 +245,30 @@ TODO: these rules about opening and closing the sidebar should be better organiz
   display: block;
 }
 
+/*LINKS*/
+
+:deep(.content a) {
+  text-decoration: underline;
+  text-underline-offset: 4px;
+  font-weight: var(--cr-font-weight-semibold);
+  text-decoration-color: var(--cr-color-neutral-300);
+  color: var(--cr-base-link-color);
+
+  &:visited {
+    text-decoration-color: var(--cr-color-neutral-300);
+    color: var(--cr-base-visited-link-color);
+  }
+  &:hover {
+    text-decoration-color: var(--cr-color-neutral-500);
+  }
+}
+
 /*TABLE*/
 :deep(table) {
   border-collapse: collapse;
   width: 100%;
   font-size: var(--cr-font-size-small);
+  line-height: var(--cr-line-height-dense);
   & th, td {
     text-align: start;
   }

--- a/skin/src/vue/c-view.vue
+++ b/skin/src/vue/c-view.vue
@@ -266,17 +266,17 @@ TODO: these rules about opening and closing the sidebar should be better organiz
 /*TABLE*/
 :deep(table) {
   border-collapse: collapse;
-  width: 100%;
+  overflow-x:auto;
   font-size: var(--cr-font-size-small);
   line-height: var(--cr-line-height-dense);
-  & th, td {
+  & th,
+  td {
     text-align: start;
   }
   & th {
     background-color: var(--cr-color-neutral-100);
-    padding: var(--cr-spacing-x-small) ;
+    padding: var(--cr-spacing-x-small);
     font-weight: var(--cr-font-weight-semibold);
-    
 
     &:first-child {
       border-top-left-radius: var(--cr-border-radius-large);
@@ -293,7 +293,10 @@ TODO: these rules about opening and closing the sidebar should be better organiz
       border-bottom: 1px solid var(--cr-color-neutral-200);
 
       &:last-child {
-        border-bottom: 0
+        border-bottom: 0;
+      }
+      & .mobile-column-name {
+        display: none
       }
     }
   }
@@ -339,6 +342,29 @@ TODO: Discuss and move them to a more appropriate place
 
   .resize-handle {
     display: none;
+  }
+  :deep(table.mobile-transform){
+    & thead{
+      & th {
+        display: none;
+      }
+    }
+    & tbody {
+      display: grid;
+      gap: 8px;
+      & tr {
+        display: grid;
+        border: 1px solid var(--cr-color-neutral-200);
+        border-radius: var(--cr-border-radius-medium);
+        & td {
+          & span.mobile-column-name {
+            display: block;
+            font-weight: var(--cr-font-weight-bold);
+          }
+        }
+      }
+    }
+    
   }
 }
 </style>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-300

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Add basic styles for `<table>` elements

## Clarifications
* Additional styles for the `<a>`element were necessary to provide a good table reading experience;
* Because of these additional elements, some colors were imported to the basic `style.css`on each design system.


# Screenshots & Video

**Table on document content**
<img width="1020" alt="Screenshot 2024-11-28 at 10 26 38" src="https://github.com/user-attachments/assets/c65bbe1b-0217-4b72-ab20-11338bf47b56">

**Attachments table**

<img width="947" alt="Screenshot 2024-11-28 at 10 28 11" src="https://github.com/user-attachments/assets/84a905b3-90f3-47c2-87c1-dab7add0e794">


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes 
* Backport on branches:
  * N/A