### PR TITLE
CRISTAL-324: Bad layout / margin for the create page button and navigation tree

### DIFF
--- a/skin/src/vue/c-sidebar-panel.vue
+++ b/skin/src/vue/c-sidebar-panel.vue
@@ -36,10 +36,24 @@ defineProps<{
   </div>
 </template>
 <style scoped>
+
+.c-sidebar-panel {
+  display:flex;
+  flex-flow: column;
+  gap: var(--cr-spacing-x-small);
+}
+
+.sidebar-content {
+  display: flex;
+  flex-flow: column;
+  gap: var(--cr-spacing-x-small);
+}
+
 .header {
   display: flex;
   flex-flow: row;
 }
+
 .title {
   color: var(--cr-color-neutral-500);
   font-size: var(--cr-font-size-small);

--- a/skin/src/vue/c-sidebar-panel.vue
+++ b/skin/src/vue/c-sidebar-panel.vue
@@ -36,9 +36,8 @@ defineProps<{
   </div>
 </template>
 <style scoped>
-
 .c-sidebar-panel {
-  display:flex;
+  display: flex;
   flex-flow: column;
   gap: var(--cr-spacing-x-small);
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-324

# Changes

## Description

* This PR fixes a small inconsistency of spacing between the buttons and tree navigation on the sidebar panel

## Clarifications

* -

# Screenshots & Video

<img width="248" alt="Screenshot 2024-12-03 at 09 08 22" src="https://github.com/user-attachments/assets/d9f370ee-7bc1-43c2-a90d-aa67b3a1d86f">


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A