### PR TITLE
CRISTAL-364: Breadcrumb links not working with Shoelace

### DIFF
--- a/core/hierarchy/hierarchy-xwiki/package.json
+++ b/core/hierarchy/hierarchy-xwiki/package.json
@@ -27,6 +27,9 @@
     "@xwiki/cristal-authentication-api": "workspace:*",
     "@xwiki/cristal-backend-api": "workspace:*",
     "@xwiki/cristal-hierarchy-api": "workspace:*",
+    "@xwiki/cristal-model-api": "workspace:*",
+    "@xwiki/cristal-model-reference-api": "workspace:*",
+    "@xwiki/cristal-model-remote-url-api": "workspace:*",
     "@xwiki/cristal-xwiki-utils": "workspace:*",
     "inversify": "6.1.4"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -868,6 +868,15 @@ importers:
       '@xwiki/cristal-hierarchy-api':
         specifier: workspace:*
         version: link:../hierarchy-api
+      '@xwiki/cristal-model-api':
+        specifier: workspace:*
+        version: link:../../model/model-api
+      '@xwiki/cristal-model-reference-api':
+        specifier: workspace:*
+        version: link:../../model/model-reference/model-reference-api
+      '@xwiki/cristal-model-remote-url-api':
+        specifier: workspace:*
+        version: link:../../model/model-remote-url/model-remote-url-api
       '@xwiki/cristal-xwiki-utils':
         specifier: workspace:*
         version: link:../../xwiki/xwiki-utils

--- a/skin/src/vue/c-content.vue
+++ b/skin/src/vue/c-content.vue
@@ -67,7 +67,6 @@ const currentPageName: ComputedRef<string> = computed(() => {
   );
 });
 
-const breadcrumbRoot = ref(undefined);
 const contentRoot = ref(undefined);
 
 const content: ComputedRef<string | undefined> = computed(() => {
@@ -122,10 +121,6 @@ watch(
 onUpdated(() => {
   ContentTools.transformImages(cristal, "xwikicontent");
 
-  if (cristal && breadcrumbRoot.value) {
-    ContentTools.listenToClicks(breadcrumbRoot.value, cristal);
-  }
-
   if (cristal && contentRoot.value) {
     ContentTools.listenToClicks(contentRoot.value, cristal);
     ContentTools.transformMacros(contentRoot.value, cristal);
@@ -148,11 +143,7 @@ onUpdated(() => {
     <alerts-toasts></alerts-toasts>
 
     <div class="page-header">
-      <!-- This div lets us reference an actual HTML element,
-             to be used in `ContentTools.listenToClicks()`. -->
-      <div id="breadcrumbRoot" ref="breadcrumbRoot">
-        <XBreadcrumb class="breadcrumb" :items="breadcrumbItems"></XBreadcrumb>
-      </div>
+      <XBreadcrumb class="breadcrumb" :items="breadcrumbItems"></XBreadcrumb>
       <x-btn circle size="small" variant="primary" color="primary">
         <c-icon
           class="new-page"

--- a/sources/xwiki/mock-server/src/index.ts
+++ b/sources/xwiki/mock-server/src/index.ts
@@ -154,6 +154,38 @@ app.get(
 );
 
 app.get(
+  "/xwiki/rest/wikis/xwiki/spaces/Deep1/pages/Deep2",
+  (req: Request, res: Response) => {
+    res.appendHeader("Access-Control-Allow-Origin", "*");
+
+    res.json({
+      hierarchy: {
+        items: [
+          {
+            label: "xwiki",
+            name: "xwiki",
+            type: "wiki",
+            url: `${req.protocol}://${req.headers.host}/xwiki/bin/view/Main/`,
+          },
+          {
+            label: "Deep1",
+            name: "Deep1",
+            type: "space",
+            url: `${req.protocol}://${req.headers.host}/xwiki/bin/view/Deep1/`,
+          },
+          {
+            label: "Deep2",
+            name: "Deep2",
+            type: "document",
+            url: `${req.protocol}://${req.headers.host}/xwiki/bin/view/Deep1/Deep2`,
+          },
+        ],
+      },
+    });
+  },
+);
+
+app.get(
   "/xwiki/rest/wikis/xwiki/spaces/Main/pages/WebHome/history",
   (_req: Request, res: Response) => {
     res.appendHeader("Access-Control-Allow-Origin", "*");

--- a/web/e2e/main-page.spec.ts
+++ b/web/e2e/main-page.spec.ts
@@ -101,11 +101,11 @@ configs.forEach(
 
       expect(breadcrumbItems.length).toEqual(2);
       await expect(breadcrumbItems[0].getText()).toContainText("Home");
-      expect(await breadcrumbItems[0].getLink()).toEqual(
+      expect(await breadcrumbItems[0].getLinkTarget()).toEqual(
         "#/Main.WebHome/view",
       );
       await expect(breadcrumbItems[1].getText()).toContainText("Main");
-      expect(await breadcrumbItems[1].getLink()).toEqual(
+      expect(await breadcrumbItems[1].getLinkTarget()).toEqual(
         "#/Main.WebHome/view",
       );
     });
@@ -121,23 +121,23 @@ configs.forEach(
 
       expect(navigationTreeNodes.length).toEqual(4);
       await expect(navigationTreeNodes[0].getText()).toContainText("Help");
-      expect(await navigationTreeNodes[0].getLink()).toEqual(
+      expect(await navigationTreeNodes[0].getLinkTarget()).toEqual(
         "#/Help.WebHome/view",
       );
       await expect(navigationTreeNodes[1].getText()).toContainText(
         "Terminal Page",
       );
-      expect(await navigationTreeNodes[1].getLink()).toEqual("#/Terminal/view");
+      expect(await navigationTreeNodes[1].getLinkTarget()).toEqual("#/Terminal/view");
       await expect(navigationTreeNodes[2].getText()).toContainText(
         "Deep Page Root",
       );
-      expect(await navigationTreeNodes[2].getLink()).toEqual(
+      expect(await navigationTreeNodes[2].getLinkTarget()).toEqual(
         "#/Deep1.WebHome/view",
       );
       await expect(navigationTreeNodes[3].getText()).toContainText(
         "Cristal Wiki",
       );
-      expect(await navigationTreeNodes[3].getLink()).toEqual(
+      expect(await navigationTreeNodes[3].getLinkTarget()).toEqual(
         "#/Main.WebHome/view",
       );
 
@@ -145,7 +145,7 @@ configs.forEach(
       const children = await navigationTreeNodes[2].getChildren();
       expect(children.length).toEqual(1);
       await expect(children[0].getText()).toContainText("Deep Page Leaf");
-      expect(await children[0].getLink()).toEqual("#/Deep1.Deep2/view");
+      expect(await children[0].getLinkTarget()).toEqual("#/Deep1.Deep2/view");
     });
 
     test(`[${name}] has working history`, async ({ page }) => {
@@ -195,6 +195,42 @@ configs.forEach(
         "Type '/' to show the available actions"
       );
       expect(editorContent).toBeEmpty();
+    });
+
+
+    test(`[${name}] has working navigation`, async ({ page }) => {
+      await page.goto(localDefaultPage);
+
+      const sidebar = new SidebarPageObject(page);
+      await sidebar.openSidebar();
+      const navigationTreeNodes = await new NavigationTreePageObject(
+        page,
+        designSystem,
+      ).findItems();
+
+      expect(await navigationTreeNodes[2].getLinkTarget()).toEqual(
+        "#/Deep1.WebHome/view",
+      );
+      await navigationTreeNodes[2].expand();
+      const children = await navigationTreeNodes[2].getChildren();
+      expect(await children[0].getLinkTarget()).toEqual("#/Deep1.Deep2/view");
+
+      // We navigate to Deep1.Deep2 through the Navigation Tree.
+      await children[0].getLink().click();
+      expect(page.url()).toMatch(/#\/Deep1\.Deep2\/view$/);
+      await sidebar.hideSidebar();
+
+      const breadcrumbItems = await new BreadcrumbPageObject(
+        page,
+        designSystem,
+      ).findItems();
+      expect(await breadcrumbItems[1].getLinkTarget()).toEqual(
+        "#/Deep1.WebHome/view",
+      );
+
+      // We navigate to Deep1.WebHome through the Breadcrumb.
+      await breadcrumbItems[1].getLink().click();
+      expect(page.url()).toMatch(/#\/Deep1\.WebHome\/view$/);
     });
 
     if (offlineDefaultPage) {

--- a/web/e2e/main-page.spec.ts
+++ b/web/e2e/main-page.spec.ts
@@ -102,11 +102,11 @@ configs.forEach(
       expect(breadcrumbItems.length).toEqual(2);
       await expect(breadcrumbItems[0].getText()).toContainText("Home");
       expect(await breadcrumbItems[0].getLink()).toEqual(
-        "http://localhost:15680/xwiki/bin/view/Main/",
+        "#/Main.WebHome/view",
       );
       await expect(breadcrumbItems[1].getText()).toContainText("Main");
       expect(await breadcrumbItems[1].getLink()).toEqual(
-        "http://localhost:15680/xwiki/bin/view/Main/",
+        "#/Main.WebHome/view",
       );
     });
 

--- a/web/e2e/pageObjects/Breadcrumb.ts
+++ b/web/e2e/pageObjects/Breadcrumb.ts
@@ -31,9 +31,14 @@ export interface BreadcrumbSegmentElement {
   getText(): Locator;
 
   /**
+   * @returns the segment link
+   */
+  getLink(): Locator;
+
+  /**
    * @returns the href value of the segment link
    */
-  getLink(): Promise<string>;
+  getLinkTarget(): Promise<string>;
 }
 
 /**
@@ -63,9 +68,11 @@ export class BreadcrumbPageObject {
           getText() {
             return element;
           },
-          async getLink() {
-            const link = element.locator(".breadcrumb-item__label--link");
-            return (await link.getAttribute("href"))!;
+          getLink() {
+            return element.locator(".breadcrumb-item__label--link");
+          },
+          async getLinkTarget() {
+            return (await this.getLink().getAttribute("href"))!;
           },
         };
       },
@@ -78,8 +85,11 @@ export class BreadcrumbPageObject {
         getText() {
           return element;
         },
-        async getLink() {
-          return (await element.getAttribute("href"))!;
+        getLink() {
+          return element;
+        },
+        async getLinkTarget() {
+          return (await this.getLink().getAttribute("href"))!;
         },
       };
     });

--- a/web/e2e/pageObjects/Breadcrumb.ts
+++ b/web/e2e/pageObjects/Breadcrumb.ts
@@ -57,7 +57,7 @@ export class BreadcrumbPageObject {
 
   private async findItemsShoelace(): Promise<BreadcrumbSegmentElement[]> {
     return await this.findItemsInternal(
-      "#breadcrumbRoot sl-breadcrumb sl-breadcrumb-item",
+      ".page-header sl-breadcrumb sl-breadcrumb-item",
       (element) => {
         return {
           getText() {
@@ -73,7 +73,7 @@ export class BreadcrumbPageObject {
   }
 
   private async findItemsVuetify(): Promise<BreadcrumbSegmentElement[]> {
-    return await this.findItemsInternal("#breadcrumbRoot li a", (element) => {
+    return await this.findItemsInternal(".page-header .v-breadcrumbs li a", (element) => {
       return {
         getText() {
           return element;

--- a/web/e2e/pageObjects/NavigationTree.ts
+++ b/web/e2e/pageObjects/NavigationTree.ts
@@ -31,9 +31,14 @@ export interface NavigationTreeNode {
   getText(): Locator;
 
   /**
+   * @returns the node link
+   */
+  getLink(): Locator;
+
+  /**
    * @returns the href value of the node link
    */
-  getLink(): Promise<string>;
+  getLinkTarget(): Promise<string>;
 
   /**
    * @returns the children of the node
@@ -78,8 +83,11 @@ export class NavigationTreePageObject {
       getText() {
         return label;
       },
-      async getLink() {
-        return (await label.getAttribute("href"))!;
+      getLink() {
+        return label;
+      },
+      async getLinkTarget() {
+        return (await this.getLink().getAttribute("href"))!;
       },
       async getChildren() {
         return await NavigationTreePageObject.findItemsInternal(
@@ -99,8 +107,11 @@ export class NavigationTreePageObject {
       getText() {
         return label;
       },
-      async getLink() {
-        return (await label.getAttribute("href"))!;
+      getLink() {
+        return label;
+      },
+      async getLinkTarget() {
+        return (await this.getLink().getAttribute("href"))!;
       },
       async getChildren() {
         return await NavigationTreePageObject.findItemsInternal(


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-364

# Changes

## Description

The previous Breadcrumb implementation was using direct XWiki links, obtained from XWiki's API, and relied on a "click listener" set on the links. However, after the refactoring done for [CRISTAL-274](https://jira.xwiki.org/browse/CRISTAL-274), the listener seems to no longer work properly with Shoelace components (that use a lot of shadow DOMs). As such, this implementation drops the listener and makes proper local Cristal links instead, which should be more stable.

## Clarifications

While using the ModelReference API for this PR, I noticed a few edge cases that were not properly handled (my test instance has a few documents with special characters, and they were not properly escaped). So I fixed them in both the parser and serializer, and also added a unit test for this.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
The test suite was executed locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A