### PR TITLE
CRISTAL-366: Special characters not properly handled in XWiki referen…

### DIFF
--- a/core/model/model-reference/model-reference-xwiki/src/__tests__/defaultLocalURLSerializer.test.ts
+++ b/core/model/model-reference/model-reference-xwiki/src/__tests__/defaultLocalURLSerializer.test.ts
@@ -61,4 +61,14 @@ describe("defaultLocalURLSerializer", () => {
       ),
     ).to.eq("Page");
   });
+  it("serialize a document reference with special characters", () => {
+    expect(
+      serializer.serialize(
+        new DocumentReference(
+          "Page 0.1\\2",
+          new SpaceReference(new WikiReference("wiki"), "S1.1", "S2\\1"),
+        ),
+      ),
+    ).to.eq("wiki:S1\\.1.S2\\\\1.Page 0\\.1\\\\2");
+  });
 });

--- a/core/model/model-reference/model-reference-xwiki/src/xWikiModelReferenceSerializer.ts
+++ b/core/model/model-reference/model-reference-xwiki/src/xWikiModelReferenceSerializer.ts
@@ -31,6 +31,13 @@ import { injectable } from "inversify";
 
 @injectable()
 export class XWikiModelReferenceSerializer implements ModelReferenceSerializer {
+  private escapeSegment(segment: string): string {
+    // Dots in XWiki references separate segments, so when inside a segment
+    // they need to be escaped with a '\'. At the same time, using '\' as an
+    // escape character means it needs to be escaped as well.
+    return segment.replace(/(\.|\\)/g, "\\$1");
+  }
+
   serialize(reference?: EntityReference): string | undefined {
     if (!reference) {
       return undefined;
@@ -43,7 +50,7 @@ export class XWikiModelReferenceSerializer implements ModelReferenceSerializer {
       case SPACE: {
         const spaceReference = reference as SpaceReference;
         const wiki = this.serialize(spaceReference.wiki);
-        const spaces = spaceReference.names.join(".");
+        const spaces = spaceReference.names.map(this.escapeSegment).join(".");
         if (wiki === undefined) {
           return spaces;
         } else {
@@ -53,7 +60,7 @@ export class XWikiModelReferenceSerializer implements ModelReferenceSerializer {
       case DOCUMENT: {
         const documentReference = reference as DocumentReference;
         const spaces = this.serialize(documentReference.space);
-        const name = documentReference.name;
+        const name = this.escapeSegment(documentReference.name);
         if (spaces === undefined || spaces == "") {
           return name;
         } else {

--- a/core/model/model-remote-url/model-remote-url-xwiki/src/xWikiRemoteURLParser.ts
+++ b/core/model/model-remote-url/model-remote-url-xwiki/src/xWikiRemoteURLParser.ts
@@ -44,10 +44,12 @@ class XWikiRemoteURLParser implements RemoteURLParser {
     const baseURL = new URL(baseURLstr);
     const url = new URL(urlStr);
 
-    const endPath = decodeURIComponent(
-      url.pathname.replace(baseURL.pathname, ""),
-    );
-    let segments = endPath.split("/");
+    const endPath = decodeURI(url.pathname.replace(baseURL.pathname, ""));
+    // Using decodeURI will not decode '/' characters inside a segment, so we
+    // do it manually.
+    let segments = endPath
+      .split("/")
+      .map((segment) => segment.replace(/%2F/g, "/"));
     if (segments[0] === "") {
       segments = segments.slice(1);
     }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-366

# Changes

## Description

This adds handling for some special characters in XWiki references, as well as a unit test.

## Clarifications

N/A

# Screenshots & Video

N/A

# Executed Tests

The test suite was executed locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A