### PR TITLE
CRISTAL-236: Navigation tree with no child sometimes have an expand button

### DIFF
--- a/core/navigation-tree/navigation-tree-filesystem/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-filesystem/src/components/componentsInit.ts
@@ -75,7 +75,10 @@ class FileSystemNavigationTreeSource implements NavigationTreeSource {
               page: id,
             },
           }).href,
-          has_children: true, // TODO: Detect empty folders.
+          has_children:
+            (await fileSystemStorage.listChildren(id)).filter(
+              (c: string) => c != "attachments",
+            ).length > 0,
         });
       }
     }

--- a/core/navigation-tree/navigation-tree-nextcloud/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-nextcloud/src/components/componentsInit.ts
@@ -56,26 +56,29 @@ class NextcloudNavigationTreeSource implements NavigationTreeSource {
   async getChildNodes(id?: string): Promise<Array<NavigationTreeNode>> {
     const currentId = id ? id : "";
     const navigationTree: Array<NavigationTreeNode> = [];
+    const currentDepth = currentId ? currentId.split("/").length : 0;
 
     const subdirectories = await this.getSubDirectories(currentId);
     for (const d of subdirectories) {
       const spaces = d.split("/");
       const currentPageData = await this.cristalApp.getPage(d);
-      navigationTree.push({
-        id: d,
-        label:
-          currentPageData && currentPageData.name
-            ? currentPageData.name
-            : spaces[spaces.length - 1],
-        location: new SpaceReference(undefined, ...spaces),
-        url: this.cristalApp.getRouter().resolve({
-          name: "view",
-          params: {
-            page: d,
-          },
-        }).href,
-        has_children: true, // TODO: Detect empty folders.
-      });
+      if (spaces.length == currentDepth + 1) {
+        navigationTree.push({
+          id: d,
+          label:
+            currentPageData && currentPageData.name
+              ? currentPageData.name
+              : spaces[spaces.length - 1],
+          location: new SpaceReference(undefined, ...spaces),
+          url: this.cristalApp.getRouter().resolve({
+            name: "view",
+            params: {
+              page: d,
+            },
+          }).href,
+          has_children: subdirectories.some((d2) => d2.startsWith(`${d}/`)),
+        });
+      }
     }
 
     return navigationTree;
@@ -92,7 +95,7 @@ class NextcloudNavigationTreeSource implements NavigationTreeSource {
           method: "PROPFIND",
           headers: {
             ...this.getBaseHeaders(),
-            Depth: "1",
+            Depth: "2",
           },
         },
       );
@@ -111,9 +114,7 @@ class NextcloudNavigationTreeSource implements NavigationTreeSource {
 
           // Remove attachments folders
           if (subdirectory !== "attachments") {
-            subdirectories.push(
-              `${directory ? directory + "/" : ""}${subdirectory}`,
-            );
+            subdirectories.push(urlFragments.slice(6, -1).join("/"));
           }
         }
       }

--- a/core/navigation-tree/navigation-tree-xwiki/src/components/componentsInit.ts
+++ b/core/navigation-tree/navigation-tree-xwiki/src/components/componentsInit.ts
@@ -131,6 +131,8 @@ class XWikiNavigationTreeSource implements NavigationTreeSource {
       ["data", "children"],
       ["compact", "true"],
       ["offset", offset.toString()],
+      ["showTranslations", "false"],
+      ["showAttachments", "false"],
     ]).toString();
 
     const response = await fetch(navigationTreeRequestUrl, { headers });
@@ -165,7 +167,7 @@ class XWikiNavigationTreeSource implements NavigationTreeSource {
               page: this.referenceSerializer.serialize(documentReference),
             },
           }).href,
-          has_children: treeNode.children, //TODO: ignore translations and attachments
+          has_children: treeNode.children,
         });
       }
     }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-236

# Changes

## Description

This PR adds some checks (with minimal performance hit) for FileSystem and Nextcloud to not display an expand button if a node has no child.
For XWiki, it adds filtering to the backend request through query parameters that I missed previously.
GitHub did not have this issue by design.

## Clarifications

N/A

# Screenshots & Video

N/A

# Executed Tests

The whole test suite was run locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A