### PR TITLE
CRISTAL-401: It is possible to end up with duplicate entries in the document tree

### DIFF
--- a/ds/vuetify/src/vue/x-navigation-tree.vue
+++ b/ds/vuetify/src/vue/x-navigation-tree.vue
@@ -137,21 +137,18 @@ async function expandTree() {
 async function lazyLoadChildren(item: unknown) {
   const treeItem = item as TreeItem;
   const childNodes = await treeSource.getChildNodes(treeItem.id);
-  // Check that the children array is still empty after all async calls.
-  if (treeItem.children?.length == 0) {
-    for (const child of childNodes) {
-      treeItem.children?.push({
-        id: child.id,
-        title: child.label,
-        href: child.url,
-        children: child.has_children ? [] : undefined,
-        _location: child.location,
-      });
-    }
-    // If the node doesn't have any children, we update it.
-    if (childNodes.length == 0) {
-      treeItem.children = undefined;
-    }
+  for (const child of childNodes) {
+    treeItem.children?.push({
+      id: child.id,
+      title: child.label,
+      href: child.url,
+      children: child.has_children ? [] : undefined,
+      _location: child.location,
+    });
+  }
+  // If the node doesn't have any children, we update it.
+  if (childNodes.length == 0) {
+    treeItem.children = undefined;
   }
 }
 
@@ -192,6 +189,7 @@ async function onDocumentUpdate(page: PageData) {
   let currentParent: string | undefined = undefined;
   let currentItems: TreeItem[] | undefined = rootNodes.value;
   let notFound = false;
+  let isRoot = true;
 
   currentItemsLoop: while (currentItems && !notFound) {
     for (const i of currentItems.keys()) {
@@ -210,10 +208,13 @@ async function onDocumentUpdate(page: PageData) {
         } else {
           currentParent = currentItems[i].id;
           if (!currentItems[i].children) {
+            // This node had no children, we reset this so new ones can be
+            // loaded lazily.
             currentItems[i].children = [];
           }
           currentItems = currentItems[i].children;
           parents.shift();
+          isRoot = false;
           continue currentItemsLoop;
         }
       }
@@ -222,9 +223,14 @@ async function onDocumentUpdate(page: PageData) {
   }
 
   // New page
+  if (currentItems.length == 0 && !isRoot) {
+    // We don't do anything because this node will be loaded lazily anyway.
+    return;
+  }
   const newItems = await treeSource.getChildNodes(
     currentParent ? currentParent : "",
   );
+  const currentPageParents = treeSource.getParentNodesId(props.currentPage);
   newItemsLoop: for (const newItem of newItems) {
     for (const i of currentItems!.keys()) {
       if (newItem.id == currentItems![i].id) {
@@ -238,6 +244,13 @@ async function onDocumentUpdate(page: PageData) {
       children: newItem.has_children ? [] : undefined,
       _location: newItem.location,
     });
+    if (
+      currentPageParents.length > 0 &&
+      currentPageParents[currentPageParents.length - 1] === newItem.id
+    ) {
+      // If we add a node, and it's the current page, it should be activated.
+      activatedNodes.value = [newItem.id];
+    }
   }
 }
 </script>

--- a/ds/vuetify/src/vue/x-navigation-tree.vue
+++ b/ds/vuetify/src/vue/x-navigation-tree.vue
@@ -137,18 +137,21 @@ async function expandTree() {
 async function lazyLoadChildren(item: unknown) {
   const treeItem = item as TreeItem;
   const childNodes = await treeSource.getChildNodes(treeItem.id);
-  for (const child of childNodes) {
-    treeItem.children?.push({
-      id: child.id,
-      title: child.label,
-      href: child.url,
-      children: child.has_children ? [] : undefined,
-      _location: child.location,
-    });
-  }
-  // If the node doesn't have any children, we update it.
-  if (childNodes.length == 0) {
-    treeItem.children = undefined;
+  // Check that the children array is still empty after all async calls.
+  if (treeItem.children?.length == 0) {
+    for (const child of childNodes) {
+      treeItem.children?.push({
+        id: child.id,
+        title: child.label,
+        href: child.url,
+        children: child.has_children ? [] : undefined,
+        _location: child.location,
+      });
+    }
+    // If the node doesn't have any children, we update it.
+    if (childNodes.length == 0) {
+      treeItem.children = undefined;
+    }
   }
 }
 


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/CRISTAL-401

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

There was a race condition between the tree expansion on page change, and the node creation on documentChange events. Both could start as soon as the editor was closed and then pause while fetching the children nodes.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

This is an issue only with the Vuetify implementation.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A