### PR TITLE
CRISTAL-414: Color and label issue for link in messages

### DIFF
--- a/ds/vuetify/src/vue/x-alert.vue
+++ b/ds/vuetify/src/vue/x-alert.vue
@@ -37,3 +37,11 @@ defineProps<AlertProps>();
     <slot />
   </v-alert>
 </template>
+
+<style scoped>
+:deep(.v-alert__content a.router-link-active),
+:deep(.v-alert__content a.router-link-active:visited) {
+  color: inherit;
+  text-decoration-color: inherit;
+}
+</style>

--- a/skin/langs/translation-en.json
+++ b/skin/langs/translation-en.json
@@ -9,7 +9,7 @@
   "page.edited.details": "Edited on {date}",
   "page.edited.details.user": "{user} edited on {date}",
   "information.extraTabs.title": "Information",
-  "history.alert.content": "You are currently viewing version {revision} of {pageName}. Edition is disabled.",
+  "history.alert.content": "You are currently viewing version {revision} of {pageName}. Editing is disabled.",
   "history.alert.link.label": "Click here to go back to the latest version.",
   "article.loading": "Loading..."
 }


### PR DESCRIPTION
* Fixes the color of links inside the message component of Vuetify
* Small correction on a message localization for EN language

# Jira URL

https://jira.xwiki.org/browse/CRISTAL-414

# Changes

## Description

* Fix for link colors inside the message component of Vuetify

## Clarifications

* Also fixes a small translating issue in English

# Screenshots & Video

Before: 
![image](https://github.com/user-attachments/assets/841a53b0-2d98-48ce-a152-6015dfb0d214)


After:

<img width="967" alt="Screenshot 2025-01-13 at 09 30 42" src="https://github.com/user-attachments/assets/7d2185ec-5221-4c62-bf5d-fadf489a08c1" />



# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A