### PR TITLE
CRISTAL-409: No attachments message is badly aligned

### DIFF
--- a/core/attachments/attachments-ui/src/vue/AttachmentsTable.vue
+++ b/core/attachments/attachments-ui/src/vue/AttachmentsTable.vue
@@ -56,9 +56,9 @@ function attachmentName(name: string) {
 }
 </script>
 <template>
-  <span v-if="isLoading">{{ t("attachments.tab.loading") }}</span>
-  <span v-else-if="errorMessage">{{ errorMessage }}</span>
-  <span v-else-if="attachments.length == 0">
+  <span class="str-loading" v-if="isLoading">{{ t("attachments.tab.loading") }}</span>
+  <span class="str-error" v-else-if="errorMessage">{{ errorMessage }}</span>
+  <span class="str-no-attachment" v-else-if="attachments.length == 0">
     {{ t("attachments.tab.noAttachments") }}
   </span>
   <table v-else class="mobile-transform">
@@ -124,3 +124,8 @@ function attachmentName(name: string) {
     </tbody>
   </table>
 </template>
+<style scoped>
+.v-card-text .str-no-attachment {
+  padding: 0 var(--cr-spacing-medium);
+}
+</style>


### PR DESCRIPTION
* Fix for the alignment issue on Vuetify

# Jira URL

https://jira.xwiki.org/browse/CRISTAL-409

# Changes

## Description

* Fix the spacing issue that's occuring when using the Vuetify DS

## Clarifications

-

# Screenshots & Video

Before:
<img width="262" alt="Screenshot 2025-01-13 at 13 04 26" src="https://github.com/user-attachments/assets/89824eb5-5126-4b8d-b782-c636a053927f" />

After:
<img width="264" alt="Screenshot 2025-01-13 at 13 04 14" src="https://github.com/user-attachments/assets/24427ee0-7fa8-421c-a87c-80aa69dd12b7" />


# Executed Tests

 -

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A