### PR TITLE
CRISTAL-422: Implement styles for external links

### DIFF
--- a/editors/tiptap/src/extensions/link.ts
+++ b/editors/tiptap/src/extensions/link.ts
@@ -41,6 +41,29 @@ export default function initLinkExtension(
   }
 
   return Link.extend({
+    addAttributes() {
+      const parents = this.parent?.();
+      return {
+        ...parents,
+        external: {
+          default: null,
+          renderHTML(attributes) {
+            const classes = [];
+            // Add the wikiexternallink class on links that are not marked as internal.
+            // We do so by checking if the 'internal-link' class is defined on the element.
+            if (
+              !attributes.class ||
+              !attributes.class.split(" ").includes("internal-link")
+            ) {
+              classes.push("wikiexternallink");
+            }
+            return {
+              class: classes.join(" "),
+            };
+          },
+        },
+      };
+    },
     addStorage() {
       return {
         markdown: {

--- a/skin/src/vue/c-article.vue
+++ b/skin/src/vue/c-article.vue
@@ -260,4 +260,29 @@ watch(
 .doc-header-inner {
   padding: 0;
 }
+
+/* External links style. */
+:deep(.wikiexternallink) {
+  font-style: italic;
+  position: relative;
+  display: inline-flex;
+}
+
+:deep(.wikiexternallink a:after),
+:deep(a.wikiexternallink:after) {
+  /*
+  TODO: Try to make this customisable, it is dependant on bootstrap icons for now.
+  */
+  content: "\F1C5";
+  display: inline-block;
+  font-family: bootstrap-icons;
+  font-style: normal;
+  font-weight: bold;
+  text-transform: none;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  font-size: 0.7rem;
+  text-decoration: none;
+  margin-left: 4px;
+}
 </style>

--- a/skin/src/vue/c-view.vue
+++ b/skin/src/vue/c-view.vue
@@ -323,6 +323,25 @@ TODO: Discuss and move them to a more appropriate place
 */
 :deep(.wikiexternallink) {
   font-style: italic;
+  position: relative;
+  display: inline-flex;
+}
+
+:deep(.wikiexternallink a:after) {
+  /*
+  TODO: Try to make this customisable, it is dependant on bootstrap icons for now.
+  */
+  content: "\F1C5";
+  display: inline-block;
+  font-family: bootstrap-icons;
+  font-style: normal;
+  font-weight: bold;
+  text-transform: none;
+  line-height: 1;
+  -webkit-font-smoothing: antialiased;
+  font-size: 0.7rem;
+  text-decoration: none;
+  margin-left: 4px;
 }
 
 @container xwCristal (max-width: 600px) {

--- a/skin/src/vue/c-view.vue
+++ b/skin/src/vue/c-view.vue
@@ -321,29 +321,6 @@ TODO: these rules about opening and closing the sidebar should be better organiz
 WIKI STYLES
 TODO: Discuss and move them to a more appropriate place
 */
-:deep(.wikiexternallink) {
-  font-style: italic;
-  position: relative;
-  display: inline-flex;
-}
-
-:deep(.wikiexternallink a:after) {
-  /*
-  TODO: Try to make this customisable, it is dependant on bootstrap icons for now.
-  */
-  content: "\F1C5";
-  display: inline-block;
-  font-family: bootstrap-icons;
-  font-style: normal;
-  font-weight: bold;
-  text-transform: none;
-  line-height: 1;
-  -webkit-font-smoothing: antialiased;
-  font-size: 0.7rem;
-  text-decoration: none;
-  margin-left: 4px;
-}
-
 @container xwCristal (max-width: 600px) {
   :deep(.wrapper.sidebar-is-collapsed) {
     &:has(.main-sidebar.is-visible) {


### PR DESCRIPTION
* Implemented an icon for the external links as it is in XWiki Standard

# Jira URL

https://jira.xwiki.org/projects/CRISTAL/issues/CRISTAL-422

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Provides proper styles for the external link icon

## Clarifications

* There was a style for external links before, but it was only an italic text that didn't provide much context.
* In this implementation we are using the Bootstrap icons pack,

# Screenshots & Video

Before:
![image](https://github.com/user-attachments/assets/39da1fa1-68ed-4991-a34e-2ba8650e90f1)

After:
<img alt="Screenshot 2025-01-15 at 11 18 50" src="https://github.com/user-attachments/assets/57cc17bb-5f75-4990-94bd-1dddbcf1bbaa" />




# Executed Tests

 -

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A