### PR TITLE
CRISTAL-419: Attachments table is misaligned on Vuetify

### DIFF
--- a/core/attachments/attachments-ui/src/vue/AttachmentsTable.vue
+++ b/core/attachments/attachments-ui/src/vue/AttachmentsTable.vue
@@ -130,4 +130,7 @@ function attachmentName(name: string) {
 .v-card-text .str-no-attachment {
   padding: 0 var(--cr-spacing-medium);
 }
+table {
+  margin: 0 var(--cr-spacing-medium);
+}
 </style>


### PR DESCRIPTION
- Fix to the table margins

# Jira URL

https://jira.xwiki.org/projects/CRISTAL/issues/CRISTAL-419

# Changes

## Description

* This PR fizes the alignment error on the attachment table

## Clarifications

* This is similar to CRISTAL-409, but I didn't notice until the previous PR created.

# Screenshots & Video

Before:
<img width="265" alt="Screenshot 2025-01-15 at 12 59 17" src="https://github.com/user-attachments/assets/78180f83-d079-4533-946f-c0a8b8cab7ab" />

After:
<img width="223" alt="Screenshot 2025-01-15 at 12 59 43" src="https://github.com/user-attachments/assets/6de6264e-ff39-425a-a261-96059ad234c8" />


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A