### PR TITLE
CRISTAL-420: Info-actions and more options buttons have different sizes

### DIFF
--- a/core/info-actions/info-actions-ui/src/vue/InfoAction.vue
+++ b/core/info-actions/info-actions-ui/src/vue/InfoAction.vue
@@ -40,7 +40,7 @@ const counter = await props.infoAction.counter();
 
 <template>
   <div :class="['info-action', infoAction.id]">
-    <c-icon :name="infoAction.iconName" :size="Size.Small"></c-icon>
+    <c-icon :name="infoAction.iconName" :size="Size.Medium"></c-icon>
     <span class="counter">{{ counter }}</span>
     <!-- TODO: add a way to jump to the extra tabs. -->
   </div>
@@ -50,8 +50,8 @@ const counter = await props.infoAction.counter();
 .info-action {
   display: flex;
   background-color: var(--cr-color-neutral-100);
-  border-radius: 99px;
-  padding: var(--cr-spacing-2x-small) var(--cr-spacing-2x-small);
+  border-radius: var(--cr-border-radius-medium);
+  padding: var(--cr-spacing-x-small) var(--cr-spacing-x-small);
   font-size: var(--cr-font-size-medium);
   flex-flow: row;
   gap: var(--cr-spacing-2x-small);

--- a/core/info-actions/info-actions-ui/src/vue/InfoAction.vue
+++ b/core/info-actions/info-actions-ui/src/vue/InfoAction.vue
@@ -19,7 +19,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 -->
 
 <script lang="ts" setup>
-import { CIcon, Size } from "@xwiki/cristal-icons";
+import { CIcon } from "@xwiki/cristal-icons";
 import { InfoAction } from "@xwiki/cristal-info-actions-api";
 import { watch } from "vue";
 import { useRoute } from "vue-router";
@@ -40,7 +40,7 @@ const counter = await props.infoAction.counter();
 
 <template>
   <div :class="['info-action', infoAction.id]">
-    <c-icon :name="infoAction.iconName" :size="Size.Medium"></c-icon>
+    <c-icon :name="infoAction.iconName"></c-icon>
     <span class="counter">{{ counter }}</span>
     <!-- TODO: add a way to jump to the extra tabs. -->
   </div>


### PR DESCRIPTION
- Padding and style adjusments to the info-actions buttons

# Jira URL

https://jira.xwiki.org/projects/CRISTAL/issues/CRISTAL-420

# Changes

## Description

* This PR bring the style of info-action to be more inline to buttons on both DS.

## Clarifications

* As a future improvement, these components should probably be converted to proper buttons.

# Screenshots & Video

**Before:**
<img width="184" alt="Screenshot 2025-01-15 at 13 23 32" src="https://github.com/user-attachments/assets/346a45f2-8af3-422b-9a45-972ca8083da3" />

**After:**
<img width="164" alt="Screenshot 2025-01-15 at 13 23 51" src="https://github.com/user-attachments/assets/5f389a0d-e60f-43e3-a4d2-c89a313e3007" />


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A