### PR TITLE
CRISTAL-408: We don't check if a page already exists on page creation

### DIFF
--- a/core/model/model-reference/model-reference-xwiki/src/xWikiModelReferenceHandler.ts
+++ b/core/model/model-reference/model-reference-xwiki/src/xWikiModelReferenceHandler.ts
@@ -22,13 +22,10 @@ import {
   AttachmentReference,
   DocumentReference,
   EntityType,
+  SpaceReference,
 } from "@xwiki/cristal-model-api";
 import { injectable } from "inversify";
-import type {
-  EntityReference,
-  SpaceReference,
-  WikiReference,
-} from "@xwiki/cristal-model-api";
+import type { EntityReference, WikiReference } from "@xwiki/cristal-model-api";
 import type { ModelReferenceHandler } from "@xwiki/cristal-model-reference-api";
 
 /**
@@ -42,8 +39,8 @@ export class XWikiModelReferenceHandler implements ModelReferenceHandler {
     name: string,
     space: SpaceReference,
   ): DocumentReference {
-    space.names.push(name);
-    return new DocumentReference("WebHome", space);
+    const newSpace = new SpaceReference(space.wiki, ...space.names, name);
+    return new DocumentReference("WebHome", newSpace);
   }
 
   getTitle(reference: EntityReference): string {

--- a/skin/langs/translation-en.json
+++ b/skin/langs/translation-en.json
@@ -1,8 +1,9 @@
 {
   "third": "Third",
   "page.actions.create.label": "Create a new document",
-  "page.creation.menu.alert.action.edit": "Edit",
-  "page.creation.menu.alert.content": "The page {pageName} already exists, either use another name or edit the existing page.",
+  "page.creation.menu.alert.content": "The page {pageName} already exists, use another name.",
+  "page.creation.menu.alert.content.edit": "The page {pageName} already exists, either use another name or {link}.",
+  "page.creation.menu.alert.content.edit.link": "edit the existing page",
   "page.creation.menu.button": "New Page",
   "page.creation.menu.field.location": "Parent location",
   "page.creation.menu.field.name": "Name",

--- a/skin/langs/translation-en.json
+++ b/skin/langs/translation-en.json
@@ -1,6 +1,8 @@
 {
   "third": "Third",
   "page.actions.create.label": "Create a new document",
+  "page.creation.menu.alert.action.edit": "Edit",
+  "page.creation.menu.alert.content": "The page {pageName} already exists, either use another name or edit the existing page.",
   "page.creation.menu.button": "New Page",
   "page.creation.menu.field.location": "Parent location",
   "page.creation.menu.field.name": "Name",

--- a/skin/langs/translation-en.json
+++ b/skin/langs/translation-en.json
@@ -1,7 +1,7 @@
 {
   "third": "Third",
   "page.actions.create.label": "Create a new document",
-  "page.creation.menu.alert.content": "The page {pageName} already exists, use another name.",
+  "page.creation.menu.alert.content": "The page {pageName} already exists.",
   "page.creation.menu.alert.content.edit": "The page {pageName} already exists, either use another name or {link}.",
   "page.creation.menu.alert.content.edit.link": "edit the existing page",
   "page.creation.menu.button": "New Page",

--- a/skin/langs/translation-fr.json
+++ b/skin/langs/translation-fr.json
@@ -1,7 +1,7 @@
 {
     "third": "Troisième",
     "page.actions.create.label": "Créer un nouveau document",
-    "page.creation.menu.alert.content": "La page {pageName} existe déjà, choisissez un autre nom.",
+    "page.creation.menu.alert.content": "La page {pageName} existe déjà.",
     "page.creation.menu.alert.content.edit": "La page {pageName} existe déjà, choisissez un autre nom ou {link}.",
     "page.creation.menu.alert.content.edit.link": "éditez la page existante",
     "page.creation.menu.button": "Nouvelle page",

--- a/skin/langs/translation-fr.json
+++ b/skin/langs/translation-fr.json
@@ -1,8 +1,9 @@
 {
     "third": "Troisième",
     "page.actions.create.label": "Créer un nouveau document",
-    "page.creation.menu.alert.action.edit": "Éditer",
-    "page.creation.menu.alert.content": "La page {pageName} existe déjà, choisissez un autre nom ou éditez la page existante.",
+    "page.creation.menu.alert.content": "La page {pageName} existe déjà, choisissez un autre nom.",
+    "page.creation.menu.alert.content.edit": "La page {pageName} existe déjà, choisissez un autre nom ou {link}.",
+    "page.creation.menu.alert.content.edit.link": "éditez la page existante",
     "page.creation.menu.button": "Nouvelle page",
     "page.creation.menu.field.location": "Emplacement du parent",
     "page.creation.menu.field.name": "Nom",

--- a/skin/langs/translation-fr.json
+++ b/skin/langs/translation-fr.json
@@ -1,6 +1,8 @@
 {
     "third": "Troisième",
     "page.actions.create.label": "Créer un nouveau document",
+    "page.creation.menu.alert.action.edit": "Éditer",
+    "page.creation.menu.alert.content": "La page {pageName} existe déjà, choisissez un autre nom ou éditez la page existante.",
     "page.creation.menu.button": "Nouvelle page",
     "page.creation.menu.field.location": "Emplacement du parent",
     "page.creation.menu.field.name": "Nom",

--- a/sources/xwiki/mock-server/src/index.ts
+++ b/sources/xwiki/mock-server/src/index.ts
@@ -87,8 +87,8 @@ ${revision ? "Revision " + revision : ""}
       break;
 
     case "Main.NewPage.WebHome":
-      name = "NewPage";
-      break;
+      res.sendStatus(404);
+      return;
 
     default:
       page = id;


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-408

# Changes

## Description

This adds an alert in the page creation dialog if the page already exists, with an action to edit it instead.

## Clarifications

N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
![image](https://github.com/user-attachments/assets/02341ad2-a41c-42cb-847f-e245b59e283f)

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
The UI tests were run locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A