### PR TITLE
CRISTAL-423: Odd alignment of the border on AttachmentUploadForm component

### DIFF
--- a/ds/shoelace/src/vue/form/x-file-input.vue
+++ b/ds/shoelace/src/vue/form/x-file-input.vue
@@ -69,6 +69,12 @@ is not supported by shoelace currently.
 </template>
 
 <style scoped>
+.input {
+  display: flex;
+  align-items: center;
+  padding: var(--cr-spacing-small);
+}
+
 .input--medium {
   border-radius: var(--sl-input-border-radius-medium);
   font-size: var(--sl-input-font-size-medium);


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/projects/CRISTAL/issues/CRISTAL-423

# Changes

## Description

* On Shoelace, there's an alignment problem on the border of the uploadForm component. This PR fixes this small issue

## Clarifications

* Shoelace does not have a custom component like Vuetify so both are a bit different handling this.

# Screenshots & Video

Before:
![image](https://github.com/user-attachments/assets/99fa0639-25a8-41ca-a9c8-753ece5c9825)

After:
<img width="230" alt="Screenshot 2025-01-17 at 13 38 20" src="https://github.com/user-attachments/assets/aa7fa0dd-cb0c-4a25-91ba-f0a2245e38e9" />


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A