### PR TITLE
CRISTAL-413: Nav Tree alignment issue on Vuetify

### DIFF
--- a/ds/vuetify/src/vue/x-navigation-tree.vue
+++ b/ds/vuetify/src/vue/x-navigation-tree.vue
@@ -288,4 +288,16 @@ async function onDocumentUpdate(page: PageData) {
 :deep(.v-list-item--link) {
   cursor: default;
 }
+/*TODO: This section needs to be removed when the oficial fix is released on Vuetify
+https://github.com/vuetifyjs/vuetify/issues/20421#event-16001533054
+START FIX
+*/
+:deep(.v-treeview-item:not(.v-list-group__header)) {
+  padding-inline-start: calc(39px + 6px) !important;
+}
+
+:deep(.v-treeview-item .v-list-item__spacer) {
+  width: 4px !important;
+}
+/*END FIX*/
 </style>


### PR DESCRIPTION
* Applied a temporary fix until the Vuetify project releases the fix officially

# Jira URL

https://jira.xwiki.org/projects/CRISTAL/issues/CRISTAL-413

# Changes

## Description

* Applied a quick fix in the same way documented here: https://github.com/vuetifyjs/vuetify/commit/28ed40bc4d083ec59dc950a749305f554c1f94bd

## Clarifications

* Because this is a quick fix, a fixed value was used in place of the Vuetify's internal CSS variable

# Screenshots & Video

Before:
<img width="262" alt="Screenshot 2025-01-21 at 09 33 31" src="https://github.com/user-attachments/assets/f9ce4246-c645-4f13-8640-b215d6489149" />


After:
<img width="229" alt="Screenshot 2025-01-21 at 09 33 06" src="https://github.com/user-attachments/assets/1adb5e89-748b-4ccf-89eb-80970497320f" />


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A