### PR TITLE
CRISTAL-449: Blockquotes are not styled

### DIFF
--- a/skin/src/vue/c-article.vue
+++ b/skin/src/vue/c-article.vue
@@ -140,6 +140,15 @@ watch(
   justify-content: center;
 }
 
+:deep(blockquote) {
+  background-color: var(--cr-color-neutral-50);
+  color: var(--cr-color-neutral-600);
+  font-size: var(--cr-font-size-large);
+  border-inline-start: 2px solid var(--cr-color-neutral-200);
+  padding-inline-start: var(--cr-spacing-large);
+  margin: 0;
+}
+
 @container xwCristal (max-width: 600px) {
   .content {
     padding-left: 0 var(--cr-spacing-x-small);

--- a/skin/src/vue/c-view.vue
+++ b/skin/src/vue/c-view.vue
@@ -316,7 +316,14 @@ TODO: these rules about opening and closing the sidebar should be better organiz
     }
   }
 }
-
+:deep(blockquote) {
+  background-color: var(--cr-color-neutral-50);
+  color: var(--cr-color-neutral-600);
+  font-size: var(--cr-font-size-large);
+  border-inline-start: 2px solid var(--cr-color-neutral-200);
+  padding-inline-start: var(--cr-spacing-large);
+  margin: 0;
+}
 /*
 WIKI STYLES
 TODO: Discuss and move them to a more appropriate place

--- a/skin/src/vue/c-view.vue
+++ b/skin/src/vue/c-view.vue
@@ -316,14 +316,7 @@ TODO: these rules about opening and closing the sidebar should be better organiz
     }
   }
 }
-:deep(blockquote) {
-  background-color: var(--cr-color-neutral-50);
-  color: var(--cr-color-neutral-600);
-  font-size: var(--cr-font-size-large);
-  border-inline-start: 2px solid var(--cr-color-neutral-200);
-  padding-inline-start: var(--cr-spacing-large);
-  margin: 0;
-}
+
 /*
 WIKI STYLES
 TODO: Discuss and move them to a more appropriate place


### PR DESCRIPTION
* Added styles for the blockquote element

# Jira URL

https://jira.xwiki.org/browse/CRISTAL-449

# Changes

## Description

* Added affected styles 

## Clarifications

-

# Screenshots & Video

Before:

<img width="956" alt="Screenshot 2025-02-05 at 09 17 03" src="https://github.com/user-attachments/assets/cea86f9a-3797-42cf-9731-3d59e533487d" />

After:

<img width="1000" alt="Screenshot 2025-02-05 at 09 16 44" src="https://github.com/user-attachments/assets/6db231ec-c0b8-420a-ac28-a81475aa6bc8" />


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A