### PR TITLE
CRISTAL-450: Code block are not styled

### DIFF
--- a/skin/src/vue/c-article.vue
+++ b/skin/src/vue/c-article.vue
@@ -150,7 +150,7 @@ watch(
  * Code block style.
  * TODO: replace with a code macro rendering as soon as we support macro.
  */
- :deep(.box .code),
+:deep(.box .code),
 :deep(.doc-content.editor pre) {
   font-family: var(--cr-font-mono);
   background: var(--cr-color-neutral-100);

--- a/skin/src/vue/c-article.vue
+++ b/skin/src/vue/c-article.vue
@@ -146,6 +146,18 @@ watch(
   }
 }
 
+/*
+ * Code block style.
+ * TODO: replace with a code macro rendering as soon as we support macro.
+ */
+ :deep(.box .code),
+:deep(.doc-content.editor pre) {
+  font-family: var(--cr-font-mono);
+  background: var(--cr-color-neutral-100);
+  border-radius: var(--cr-border-radius-medium);
+  padding: var(--cr-spacing-small);
+}
+
 /*TABLE STYLES*/
 /*TODO: Check a better way to write these styles without the global tag. Currently impossible to use :deep because the html inside the document content is not assigned an ID */
 .content {

--- a/skin/src/vue/c-view.vue
+++ b/skin/src/vue/c-view.vue
@@ -253,6 +253,21 @@ TODO: these rules about opening and closing the sidebar should be better organiz
   display: block;
 }
 
+/*
+WIKI STYLES
+TODO: Discuss and move them to a more appropriate place
+*/
+
+/*CODE*/
+:deep(.box) {
+  :deep(.code) {
+    font-family: var(--cr-font-mono);
+    background: var(--cr-color-neutral-100);
+    border-radius: var(--cr-border-radius-medium);
+    padding: var(--cr-spacing-small);
+  }
+}
+
 /*LINKS*/
 
 :deep(.content a) {
@@ -316,11 +331,10 @@ TODO: these rules about opening and closing the sidebar should be better organiz
     }
   }
 }
-
 /*
-WIKI STYLES
-TODO: Discuss and move them to a more appropriate place
+END WIKI STYLES
 */
+
 @container xwCristal (max-width: 600px) {
   :deep(.wrapper.sidebar-is-collapsed) {
     &:has(.main-sidebar.is-visible) {

--- a/skin/src/vue/c-view.vue
+++ b/skin/src/vue/c-view.vue
@@ -258,16 +258,6 @@ WIKI STYLES
 TODO: Discuss and move them to a more appropriate place
 */
 
-/*CODE*/
-:deep(.box) {
-  :deep(.code) {
-    font-family: var(--cr-font-mono);
-    background: var(--cr-color-neutral-100);
-    border-radius: var(--cr-border-radius-medium);
-    padding: var(--cr-spacing-small);
-  }
-}
-
 /*LINKS*/
 
 :deep(.content a) {


### PR DESCRIPTION
* Added styles for code blocks

# Jira URL

https://jira.xwiki.org/browse/CRISTAL-450

# Changes

## Description

* Added affected styles

## Clarifications

-

# Screenshots & Video

Before:

<img width="913" alt="Screenshot 2025-02-05 at 09 18 54" src="https://github.com/user-attachments/assets/bc94f559-13cb-4b00-ada4-40ece0a2338d" />

After:

<img width="1000" alt="Screenshot 2025-02-05 at 09 19 12" src="https://github.com/user-attachments/assets/b3a69977-2561-436f-af07-88d46495409d" />


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A