### PR TITLE
CRISTAL-462: page title have a slightly different style on edit mode

### DIFF
--- a/skin/src/vue/c-content.vue
+++ b/skin/src/vue/c-content.vue
@@ -160,6 +160,7 @@ onUpdated(() => {
   font-size: var(--cr-font-size-2x-large);
   line-height: var(--cr-font-size-2x-large);
   padding-block-start: var(--cr-spacing-small);
+  font-weight: var(--cr-font-weight-bold);
 }
 
 .doc-page-actions {


### PR DESCRIPTION
* Adjusted styles for the page title

# Jira URL

https://jira.xwiki.org/browse/CRISTAL-462

# Changes

## Description

Slight variation in style of the doc title between edit and view mode.

## Clarifications

* There was a style that was being inherited by the input in edit mode that made the component differ a little bit from the view mode component, this was adjusted by adding a property directly to the class `doc-title`

# Screenshots & Video

Before: 

<img width="434" alt="Screenshot 2025-02-05 at 14 26 39" src="https://github.com/user-attachments/assets/0cfbab26-71e8-49d6-83bc-fb28e03577d4" />

After:

<img width="382" alt="Screenshot 2025-02-05 at 14 26 11" src="https://github.com/user-attachments/assets/b26e30c0-6611-47d0-8e11-9b4cb8539c54" />


# Executed Tests

 -

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A