### PR TITLE
CRISTAL-461: Toolbar is missing styles

### DIFF
--- a/editors/tiptap/src/vue/c-tiptap-bubble-menu.vue
+++ b/editors/tiptap/src/vue/c-tiptap-bubble-menu.vue
@@ -271,7 +271,9 @@ const linkAction = getLinkAction(props.editor);
   position: relative;
   display: flex;
   border-radius: var(--cr-tooltip-border-radius);
+  border: 1px solid var(--cr-color-neutral-200);
   background: white; /* TODO: define a global variable for background color */
+  box-shadow: var(--cr-shadow-medium);
 }
 
 .items > div {


### PR DESCRIPTION
* Added styles to separate the toolbar from its background

# Jira URL

https://jira.xwiki.org/browse/CRISTAL-461

# Changes

## Description

* Inclusion of styles to make the floating toolbar in edit mode more prominent/separated from the background.

## Clarifications

-

# Screenshots & Video


Before:

<img width="335" alt="Screenshot 2025-02-13 at 14 37 43" src="https://github.com/user-attachments/assets/2fe2fcff-6326-4452-9712-8365400972c1" />

After:

<img width="353" alt="Screenshot 2025-02-13 at 14 37 27" src="https://github.com/user-attachments/assets/bc9b172d-d4be-4ce8-aa2f-cffbf1f36c0a" />


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A