### PR TITLE
[Misc] Remove deprecated Vue TypeScript VSCode extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,7 +1,6 @@
 {
   "recommendations": [
     "Vue.volar",
-    "Vue.vscode-typescript-vue-plugin",
     "ms-playwright.playwright",
     "dbaeumer.vscode-eslint",
     "esbenp.prettier-vscode"


### PR DESCRIPTION
# Jira URL

N/A

# Changes

## Description

* Remove deprecated TypeScript plugin for Vue from the list of recommanded VSCode extensions

## Clarifications

N/A

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A

cc @manuelleduc 