### PR TITLE
CRISTAL-466: Whitelist Electron to run postinstall script with PNPM 11

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,5 +57,15 @@
   "engines": {
     "node": "22.13.1"
   },
-  "packageManager": "pnpm@10.2.1"
+  "packageManager": "pnpm@10.2.1",
+  "pnpm": {
+    "ignoredBuiltDependencies": [
+      "esbuild",
+      "nx",
+      "vue-demi"
+    ],
+    "onlyBuiltDependencies": [
+      "electron"
+    ]
+  }
 }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-466

# Changes

## Description

* Allow Electron to run its postinstall script when installed with PNPM 11

## Clarifications

* Starting with version 11, PNPM doesn't run postinstall scripts by default anymore. Packages need to be manually whitelisted for their script to run.

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A

cc @manuelleduc 