### PR TITLE
CRISTAL-467: Add Flatpak image

### DIFF
--- a/electron/.electron-builder.config.js
+++ b/electron/.electron-builder.config.js
@@ -50,6 +50,11 @@ module.exports = async function () {
       executableName: "cristal",
       category: "Application",
     },
+    flatpak: {
+      artifactName: "${productName}-${version}-linux-${arch}.${ext}",
+      category: "Application",
+      mimeTypes: null,
+    },
     mac: {
       artifactName: "${productName}-${version}-mac-${arch}.${ext}",
       executableName: "cristal",

--- a/electron/package.json
+++ b/electron/package.json
@@ -15,7 +15,7 @@
   },
   "main": "./main/dist/index.cjs",
   "scripts": {
-    "build:linux": "electron-builder --linux snap deb rpm AppImage --x64 --config .electron-builder.config.js --dir",
+    "build:linux": "electron-builder --linux snap deb rpm flatpak AppImage --x64 --config .electron-builder.config.js --dir",
     "build:mac": "electron-builder --mac dmg --x64 --arm64 --config .electron-builder.config.js --dir",
     "build:win": "electron-builder --win nsis msi --x64 --ia32 --config .electron-builder.config.js --dir",
     "clean": "rimraf dist",


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-467

# Changes

## Description

* Add a Flatpak to the list of Linux build outputs

## Clarifications

* Flatpak is useful for distributing under Linux, as it contains all required dependencies and also enables sandboxing
* AppImage currently [don't work properly with Ubuntu 22.04](https://github.com/electron/electron/issues/17972). Flatpak can be an alternative for users who still want to download a standalone file and get sandboxing

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A

cc @manuelleduc 