### PR TITLE
[Misc] Use re-export statements instead of import -> export

### DIFF
--- a/api/src/index.ts
+++ b/api/src/index.ts
@@ -18,46 +18,22 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { registerAsyncComponent } from "./api/designSystemLoader.js";
-import { DefaultPageData } from "./components/DefaultPageData.js";
-import { JSONLDDocument } from "./components/JSONLDDocument.js";
-import ComponentInit from "./components/componentsInit.js";
-import { DefaultLogger } from "./components/defaultLogger.js";
-import { DefaultLoggerConfig } from "./components/defaultLoggerConfig.js";
-import { DefaultWikiConfig } from "./components/defaultWikiConfig.js";
-import type { PageData } from "./api/PageData.js";
-import type { WikiConfig } from "./api/WikiConfig.js";
-import type { AttachmentsData } from "./api/attachmentsData";
-import type { CristalApp } from "./api/cristalApp.js";
-import type { DesignSystemLoader } from "./api/designSystemLoader.js";
-import type { Document } from "./api/document.js";
-import type { Logger } from "./api/logger.js";
-import type { LoggerConfig } from "./api/loggerConfig.js";
-import type { PageAttachment } from "./api/pageAttachment";
-import type { SkinManager } from "./api/skinManager.js";
-import type { Storage } from "./api/storage.js";
-import type { WrappingStorage } from "./api/wrappingStorage.js";
-
-export type {
-  AttachmentsData,
-  CristalApp,
-  DesignSystemLoader,
-  Document,
-  Logger,
-  LoggerConfig,
-  PageAttachment,
-  PageData,
-  SkinManager,
-  Storage,
-  WikiConfig,
-  WrappingStorage,
-};
-export {
-  ComponentInit,
-  DefaultLogger,
-  DefaultLoggerConfig,
-  DefaultPageData,
-  DefaultWikiConfig,
-  JSONLDDocument,
-  registerAsyncComponent,
-};
+export { registerAsyncComponent } from "./api/designSystemLoader.js";
+export { DefaultPageData } from "./components/DefaultPageData.js";
+export { JSONLDDocument } from "./components/JSONLDDocument.js";
+export { default as ComponentInit } from "./components/componentsInit.js";
+export { DefaultLogger } from "./components/defaultLogger.js";
+export { DefaultLoggerConfig } from "./components/defaultLoggerConfig.js";
+export { DefaultWikiConfig } from "./components/defaultWikiConfig.js";
+export type { PageData } from "./api/PageData.js";
+export type { WikiConfig } from "./api/WikiConfig.js";
+export type { AttachmentsData } from "./api/attachmentsData";
+export type { CristalApp } from "./api/cristalApp.js";
+export type { DesignSystemLoader } from "./api/designSystemLoader.js";
+export type { Document } from "./api/document.js";
+export type { Logger } from "./api/logger.js";
+export type { LoggerConfig } from "./api/loggerConfig.js";
+export type { PageAttachment } from "./api/pageAttachment";
+export type { SkinManager } from "./api/skinManager.js";
+export type { Storage } from "./api/storage.js";
+export type { WrappingStorage } from "./api/wrappingStorage.js";

--- a/core/alerts/alerts-ui/src/index.ts
+++ b/core/alerts/alerts-ui/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import AlertsToasts from "./vue/AlertsToasts.vue";
-
-export { AlertsToasts };
+export { default as AlertsToasts } from "./vue/AlertsToasts.vue";

--- a/core/alerts/alerts-ui/src/translations.ts
+++ b/core/alerts/alerts-ui/src/translations.ts
@@ -21,8 +21,7 @@
 import en from "../langs/translation-en.json";
 import fr from "../langs/translation-fr.json";
 
-const translations: Record<string, Record<string, string>> = {
+export default {
   en,
   fr,
-};
-export default translations;
+} satisfies Record<string, Record<string, string>>;

--- a/core/authentication/authentication-api/src/index.ts
+++ b/core/authentication/authentication-api/src/index.ts
@@ -18,8 +18,6 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import type { AuthenticationManager } from "./authenticationManager";
-import type { AuthenticationManagerProvider } from "./authenticationManagerProvider";
-import type { UserDetails } from "./userDetails";
-
-export { AuthenticationManager, AuthenticationManagerProvider, UserDetails };
+export type { AuthenticationManager } from "./authenticationManager";
+export type { AuthenticationManagerProvider } from "./authenticationManagerProvider";
+export type { UserDetails } from "./userDetails";

--- a/core/backends/backend-api/src/index.ts
+++ b/core/backends/backend-api/src/index.ts
@@ -18,9 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { AbstractStorage } from "./abstractStorage";
-import { ComponentInit } from "./componentInit";
-import type OfflineStorage from "./offlineStorage";
-import type { StorageProvider } from "./storageProvider";
-
-export { AbstractStorage, ComponentInit, OfflineStorage, StorageProvider };
+export { AbstractStorage } from "./abstractStorage";
+export { ComponentInit } from "./componentInit";
+export type { default as OfflineStorage } from "./offlineStorage";
+export type { StorageProvider } from "./storageProvider";

--- a/core/browser/browser-default/src/index.ts
+++ b/core/browser/browser-default/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/core/date/date-api/src/index.ts
+++ b/core/date/date-api/src/index.ts
@@ -18,7 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentInit";
-import { DateService } from "./dateService";
-
-export { ComponentInit, type DateService };
+export { ComponentInit } from "./componentInit";
+export type { DateService } from "./dateService";

--- a/core/date/date-ui/src/index.ts
+++ b/core/date/date-ui/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import Date from "./vue/CDate.vue";
-
-export { Date };
+export { default as Date } from "./vue/CDate.vue";

--- a/core/extra-tabs/extra-tabs-api/src/index.ts
+++ b/core/extra-tabs/extra-tabs-api/src/index.ts
@@ -18,7 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { AbstractExtraTab } from "./ExtraTabsService";
-import type { ExtraTab, ExtraTabsService } from "./ExtraTabsService";
-
-export { AbstractExtraTab, type ExtraTab, type ExtraTabsService };
+export { AbstractExtraTab } from "./ExtraTabsService";
+export type { ExtraTab, ExtraTabsService } from "./ExtraTabsService";

--- a/core/extra-tabs/extra-tabs-ui/src/index.ts
+++ b/core/extra-tabs/extra-tabs-ui/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ExtraTabs from "./vue/ExtraTabs.vue";
-
-export { ExtraTabs };
+export { default as ExtraTabs } from "./vue/ExtraTabs.vue";

--- a/core/file-preview/file-preview-ui/src/index.ts
+++ b/core/file-preview/file-preview-ui/src/index.ts
@@ -18,7 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import FilePreview from "./vue/FilePreview.vue";
-import FileSize from "./vue/FileSize.vue";
-
-export { FilePreview, FileSize };
+export { default as FilePreview } from "./vue/FilePreview.vue";
+export { default as FileSize } from "./vue/FileSize.vue";

--- a/core/hierarchy/hierarchy-default/src/index.ts
+++ b/core/hierarchy/hierarchy-default/src/index.ts
@@ -18,7 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-import { getPageHierarchyFromPath } from "./utils";
-
-export { ComponentInit, getPageHierarchyFromPath };
+export { ComponentInit } from "./components/componentsInit";
+export { getPageHierarchyFromPath } from "./utils";

--- a/core/hierarchy/hierarchy-filesystem/src/index.ts
+++ b/core/hierarchy/hierarchy-filesystem/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/core/hierarchy/hierarchy-github/src/index.ts
+++ b/core/hierarchy/hierarchy-github/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/core/hierarchy/hierarchy-nextcloud/src/index.ts
+++ b/core/hierarchy/hierarchy-nextcloud/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/core/hierarchy/hierarchy-xwiki/src/index.ts
+++ b/core/hierarchy/hierarchy-xwiki/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/core/icons/src/index.ts
+++ b/core/icons/src/index.ts
@@ -18,7 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { Size } from "./size";
-import CIcon from "./vue/c-icon.vue";
-
-export { CIcon, Size };
+export { Size } from "./size";
+export { default as CIcon } from "./vue/c-icon.vue";

--- a/core/info-actions/info-actions-ui/src/index.ts
+++ b/core/info-actions/info-actions-ui/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import InfoActions from "./vue/InfoActions.vue";
-
-export { InfoActions };
+export { default as InfoActions } from "./vue/InfoActions.vue";

--- a/core/link-suggest/link-suggest-xwiki/src/index.ts
+++ b/core/link-suggest/link-suggest-xwiki/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/core/markdown/markdown-api/src/index.ts
+++ b/core/markdown/markdown-api/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import type { MarkdownRenderer } from "./markdownRenderer";
-
-export { MarkdownRenderer };
+export type { MarkdownRenderer } from "./markdownRenderer";

--- a/core/model/model-click-listener/src/index.ts
+++ b/core/model/model-click-listener/src/index.ts
@@ -18,7 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentInit";
-import type { ClickListener } from "./clickListener";
-
-export { type ClickListener, ComponentInit };
+export { ComponentInit } from "./componentInit";
+export type { ClickListener } from "./clickListener";

--- a/core/model/model-reference/model-reference-api/src/index.ts
+++ b/core/model/model-reference/model-reference-api/src/index.ts
@@ -18,20 +18,10 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentInit";
-import type { ModelReferenceHandler } from "./modelReferenceHandler";
-import type { ModelReferenceHandlerProvider } from "./modelReferenceHandlerProvider";
-import type { ModelReferenceParser } from "./modelReferenceParser";
-import type { ModelReferenceParserProvider } from "./modelReferenceParserProvider";
-import type { ModelReferenceSerializer } from "./modelReferenceSerializer";
-import type { ModelReferenceSerializerProvider } from "./modelReferenceSerializerProvider";
-
-export {
-  ComponentInit,
-  type ModelReferenceHandler,
-  type ModelReferenceHandlerProvider,
-  type ModelReferenceParser,
-  type ModelReferenceParserProvider,
-  type ModelReferenceSerializer,
-  type ModelReferenceSerializerProvider,
-};
+export { ComponentInit } from "./componentInit";
+export type { ModelReferenceHandler } from "./modelReferenceHandler";
+export type { ModelReferenceHandlerProvider } from "./modelReferenceHandlerProvider";
+export type { ModelReferenceParser } from "./modelReferenceParser";
+export type { ModelReferenceParserProvider } from "./modelReferenceParserProvider";
+export type { ModelReferenceSerializer } from "./modelReferenceSerializer";
+export type { ModelReferenceSerializerProvider } from "./modelReferenceSerializerProvider";

--- a/core/model/model-reference/model-reference-filesystem/src/index.ts
+++ b/core/model/model-reference/model-reference-filesystem/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./componentInit";

--- a/core/model/model-reference/model-reference-nextcloud/src/index.ts
+++ b/core/model/model-reference/model-reference-nextcloud/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./componentInit";

--- a/core/model/model-reference/model-reference-xwiki/src/index.ts
+++ b/core/model/model-reference/model-reference-xwiki/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./componentInit";

--- a/core/model/model-remote-url/model-remote-url-api/src/index.ts
+++ b/core/model/model-remote-url/model-remote-url-api/src/index.ts
@@ -18,16 +18,8 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentInit";
-import type { RemoteURLParser } from "./remoteURLParser";
-import type { RemoteURLParserProvider } from "./remoteURLParserProvider";
-import type { RemoteURLSerializer } from "./remoteURLSerializer";
-import type { RemoteURLSerializerProvider } from "./remoteURLSerializerProvider";
-
-export {
-  ComponentInit,
-  type RemoteURLParser,
-  type RemoteURLParserProvider,
-  type RemoteURLSerializer,
-  type RemoteURLSerializerProvider,
-};
+export { ComponentInit } from "./componentInit";
+export type { RemoteURLParser } from "./remoteURLParser";
+export type { RemoteURLParserProvider } from "./remoteURLParserProvider";
+export type { RemoteURLSerializer } from "./remoteURLSerializer";
+export type { RemoteURLSerializerProvider } from "./remoteURLSerializerProvider";

--- a/core/model/model-remote-url/model-remote-url-filesystem/model-remote-url-filesystem-default/src/index.ts
+++ b/core/model/model-remote-url/model-remote-url-filesystem/model-remote-url-filesystem-default/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./componentInit";

--- a/core/model/model-remote-url/model-remote-url-nextcloud/src/index.ts
+++ b/core/model/model-remote-url/model-remote-url-nextcloud/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./componentInit";

--- a/core/model/model-remote-url/model-remote-url-xwiki/src/index.ts
+++ b/core/model/model-remote-url/model-remote-url-xwiki/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./componentInit";

--- a/core/navigation-tree/navigation-tree-default/src/index.ts
+++ b/core/navigation-tree/navigation-tree-default/src/index.ts
@@ -18,7 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-import { getParentNodesIdFromPath } from "./utils";
-
-export { ComponentInit, getParentNodesIdFromPath };
+export { ComponentInit } from "./components/componentsInit";
+export { getParentNodesIdFromPath } from "./utils";

--- a/core/navigation-tree/navigation-tree-filesystem/src/index.ts
+++ b/core/navigation-tree/navigation-tree-filesystem/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/core/navigation-tree/navigation-tree-github/src/index.ts
+++ b/core/navigation-tree/navigation-tree-github/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/core/navigation-tree/navigation-tree-nextcloud/src/index.ts
+++ b/core/navigation-tree/navigation-tree-nextcloud/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/core/navigation-tree/navigation-tree-xwiki/src/index.ts
+++ b/core/navigation-tree/navigation-tree-xwiki/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/core/tiptap-extensions/tiptap-extension-image/src/index.ts
+++ b/core/tiptap-extensions/tiptap-extension-image/src/index.ts
@@ -18,7 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { initTiptapImage } from "./CristalTiptapImage";
-import { ImageInsertNode } from "./ImageInsert";
-
-export { ImageInsertNode, initTiptapImage };
+export { initTiptapImage } from "./CristalTiptapImage";
+export { ImageInsertNode } from "./ImageInsert";

--- a/core/tiptap-extensions/tiptap-link-suggest-ui/src/index.ts
+++ b/core/tiptap-extensions/tiptap-link-suggest-ui/src/index.ts
@@ -17,6 +17,4 @@
  * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
-import LinkSuggestItem from "./vue/LinkSuggestItem.vue";
-
-export { LinkSuggestItem };
+export { default as LinkSuggestItem } from "./vue/LinkSuggestItem.vue";

--- a/core/uiextension/uiextension-ui/src/index.ts
+++ b/core/uiextension/uiextension-ui/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import UIExtensions from "./vue/UIExtensions.vue";
-
-export { UIExtensions };
+export { default as UIExtensions } from "./vue/UIExtensions.vue";

--- a/core/user/user-ui/src/index.ts
+++ b/core/user/user-ui/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import User from "./vue/CUser.vue";
-
-export { User };
+export { default as User } from "./vue/CUser.vue";

--- a/ds/dsfr/src/index.ts
+++ b/ds/dsfr/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./components/componentsInit.js";
-
-export { ComponentInit };
+export { default as ComponentInit } from "./components/componentsInit.js";

--- a/ds/shoelace/src/index.ts
+++ b/ds/shoelace/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./components/componentsInit.js";
-
-export { ComponentInit };
+export { default as ComponentInit } from "./components/componentsInit.js";

--- a/ds/vuetify/src/index.ts
+++ b/ds/vuetify/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./components/componentsInit.js";
-
-export { ComponentInit };
+import { default as ComponentInit } from "./components/componentsInit.js";

--- a/editors/tiptap/src/index.ts
+++ b/editors/tiptap/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./components/componentsInit.js";
-
-export { ComponentInit };
+export { default as ComponentInit } from "./components/componentsInit.js";

--- a/electron/browser/src/index.ts
+++ b/electron/browser/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./componentsInit";

--- a/electron/link-suggest/link-suggest-filesystem/src/index.ts
+++ b/electron/link-suggest/link-suggest-filesystem/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit";
-
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit";

--- a/electron/storage/src/index.ts
+++ b/electron/storage/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./componentsInit";
-
-export { ComponentInit };
+export { default as ComponentInit } from "./componentsInit";

--- a/extension-manager/src/index.ts
+++ b/extension-manager/src/index.ts
@@ -18,20 +18,11 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./components/componentsInit";
-import { CristalLoader } from "./components/cristalLoader";
-import { DefaultExtensionConfig } from "./components/defaultExtensionConfig";
-import { DefaultExtensionManager } from "./components/defaultExtensionManager";
-import type { CristalComponent } from "./api/cristalComponent";
-import type { ExtensionConfig } from "./api/extensionConfig";
-import type { ExtensionManager } from "./api/extensionManager";
-import type { DefaultComponent } from "./components/defaultComponent";
-
-export type { CristalComponent, ExtensionConfig, ExtensionManager };
-export {
-  ComponentInit,
-  CristalLoader,
-  DefaultComponent,
-  DefaultExtensionConfig,
-  DefaultExtensionManager,
-};
+export { default as ComponentInit } from "./components/componentsInit";
+export { CristalLoader } from "./components/cristalLoader";
+export { DefaultExtensionConfig } from "./components/defaultExtensionConfig";
+export { DefaultExtensionManager } from "./components/defaultExtensionManager";
+export type { CristalComponent } from "./api/cristalComponent";
+export type { ExtensionConfig } from "./api/extensionConfig";
+export type { ExtensionManager } from "./api/extensionManager";
+export type { DefaultComponent } from "./components/defaultComponent";

--- a/extensions/menubuttons/src/index.ts
+++ b/extensions/menubuttons/src/index.ts
@@ -18,8 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { ComponentInit } from "./components/componentsInit.js";
-import type { MenuEntry } from "./api/menuEntry";
-
-export type { MenuEntry };
-export { ComponentInit };
+export { ComponentInit } from "./components/componentsInit.js";
+export type { MenuEntry } from "./api/menuEntry";

--- a/lib/src/index.ts
+++ b/lib/src/index.ts
@@ -18,8 +18,6 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { DefaultCristalApp } from "./components/DefaultCristalApp";
-import { CristalAppLoader } from "./components/cristalAppLoader";
-import { defaultComponentsList } from "./default/defaultComponentsList";
-
-export { CristalAppLoader, DefaultCristalApp, defaultComponentsList };
+export { DefaultCristalApp } from "./components/DefaultCristalApp";
+export { CristalAppLoader } from "./components/cristalAppLoader";
+export { defaultComponentsList } from "./default/defaultComponentsList";

--- a/macros/src/index.ts
+++ b/macros/src/index.ts
@@ -18,7 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./components/componentsInit.js";
-import { DefaultMacroProvider } from "./components/defaultMacroProvider";
-
-export { ComponentInit, DefaultMacroProvider };
+export { default as ComponentInit } from "./components/componentsInit.js";
+export { DefaultMacroProvider } from "./components/defaultMacroProvider";

--- a/rendering/rendering/src/index.ts
+++ b/rendering/rendering/src/index.ts
@@ -18,9 +18,6 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./components/componentsInit";
-import type { Converter } from "./api/converter";
-import type { Renderer } from "./api/renderer";
-
-export type { Converter, Renderer };
-export { ComponentInit };
+export { default as ComponentInit } from "./components/componentsInit";
+export type { Converter } from "./api/converter";
+export type { Renderer } from "./api/renderer";

--- a/rendering/wikimodel/src/index.ts
+++ b/rendering/wikimodel/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import { WikiModelTeaVM } from "./wikimodel-teavm.js";
-
-export { WikiModelTeaVM };
+export { WikiModelTeaVM } from "./wikimodel-teavm.js";

--- a/sharedworker/impl/src/index.ts
+++ b/sharedworker/impl/src/index.ts
@@ -18,7 +18,5 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./components/componentsInit";
-import type { QueueWorker } from "@xwiki/cristal-sharedworker-api";
-export type { QueueWorker };
-export { ComponentInit };
+export { default as ComponentInit } from "./components/componentsInit";
+export type { QueueWorker } from "@xwiki/cristal-sharedworker-api";

--- a/skin/src/index.ts
+++ b/skin/src/index.ts
@@ -18,32 +18,15 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./components/componentsInit";
-import { DefaultMacroData } from "./components/defaultMacroData";
-import { DefaultSkinManager } from "./components/defaultSkinManager";
-import DefaultUIXTemplateProvider from "./components/defaultUIXTemplateProvider";
-import DefaultVueTemplateProvider from "./components/defaultVueTemplateProvider";
-import CArticle from "./vue/c-article.vue";
-import CTemplate from "./vue/c-template.vue";
-import { ContentTools } from "./vue/contentTools";
-import type { MacroData } from "./api/macroData";
-import type { MacroProvider } from "./api/macroProvider";
-import type { UIXTemplateProvider } from "./api/uixTemplateProvider";
-import type { VueTemplateProvider } from "./api/vueTemplateProvider";
-
-export type {
-  MacroData,
-  MacroProvider,
-  UIXTemplateProvider,
-  VueTemplateProvider,
-};
-export {
-  CArticle,
-  CTemplate,
-  ComponentInit,
-  ContentTools,
-  DefaultMacroData,
-  DefaultSkinManager,
-  DefaultUIXTemplateProvider,
-  DefaultVueTemplateProvider,
-};
+export { default as ComponentInit } from "./components/componentsInit";
+export { DefaultMacroData } from "./components/defaultMacroData";
+export { DefaultSkinManager } from "./components/defaultSkinManager";
+export { default as DefaultUIXTemplateProvider } from "./components/defaultUIXTemplateProvider";
+export { default as DefaultVueTemplateProvider } from "./components/defaultVueTemplateProvider";
+export { default as CArticle } from "./vue/c-article.vue";
+export { default as CTemplate } from "./vue/c-template.vue";
+export { ContentTools } from "./vue/contentTools";
+export type { MacroData } from "./api/macroData";
+export type { MacroProvider } from "./api/macroProvider";
+export type { UIXTemplateProvider } from "./api/uixTemplateProvider";
+export type { VueTemplateProvider } from "./api/vueTemplateProvider";

--- a/xwiki/remoteinlineeditor/src/index.ts
+++ b/xwiki/remoteinlineeditor/src/index.ts
@@ -18,6 +18,4 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import ComponentInit from "./components/componentsInit";
-
-export { ComponentInit };
+export { default as ComponentInit } from "./components/componentsInit";


### PR DESCRIPTION
# Jira URL

N/A

# Changes

## Description

* Replace `import` followed by `export` with re-`export` statements

## Clarifications

* Instead of `import`ing a module and then `export`ing it directly, it's preferred to use a re-`export` statement:

```typescript
// Instead of:
import { obj } from './module'
export { obj }

// Write this:
export { obj } from './module'
```

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A