### PR TITLE
CRISTAL-496: Allow the file system backend root location to be configurable

### DIFF
--- a/core/browser/browser-api/src/index.ts
+++ b/core/browser/browser-api/src/index.ts
@@ -47,6 +47,13 @@ export interface BrowserApi {
    */
 
   onClose(callback: () => boolean): void;
+
+  /**
+   * Set the wiki configuration of the Cristal instance
+   * @param wikiConfig - the wiki config to use
+   * @since 0.16
+   */
+  setLocation(wikiConfig: WikiConfig): void;
 }
 
 export const name = "BrowserApi";

--- a/core/browser/browser-default/src/components/browser-api-default.ts
+++ b/core/browser/browser-default/src/components/browser-api-default.ts
@@ -49,4 +49,6 @@ export class BrowserApiDefault implements BrowserApi {
       window.removeEventListener("beforeunload", listener);
     });
   }
+
+  setLocation(): void {}
 }

--- a/core/browser/browser-default/src/components/browser-api-default.ts
+++ b/core/browser/browser-default/src/components/browser-api-default.ts
@@ -50,5 +50,9 @@ export class BrowserApiDefault implements BrowserApi {
     });
   }
 
-  setLocation(): void {}
+  setLocation(): void {
+    // At this point, we need to change the current URL on configuration
+    // switching, but this operation is already handled during app loading for
+    // the initial configuration (which is when this method is called).
+  }
 }

--- a/electron/browser/package.json
+++ b/electron/browser/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@xwiki/cristal-api": "workspace:*",
     "@xwiki/cristal-browser-api": "workspace:*",
+    "@xwiki/cristal-electron-state": "workspace:*",
     "inversify": "7.1.0"
   },
   "peerDependencies": {

--- a/electron/browser/src/components/browser-api-electron.ts
+++ b/electron/browser/src/components/browser-api-electron.ts
@@ -32,7 +32,7 @@ declare const browserElectron: APITypes;
 @injectable()
 export class BrowserApiElectron implements BrowserApi {
   switchLocation(wikiConfig: WikiConfig): void {
-    window.localStorage.setItem("currentApp", wikiConfig.name);
+    this.setLocation(wikiConfig);
     browserElectron.reloadBrowser();
   }
 
@@ -43,5 +43,10 @@ export class BrowserApiElectron implements BrowserApi {
   onClose(): void {
     // TODO: CRISTAL-429 we did not find a viable implementation to intercept the close action and display a confirm
     // dialog to ask for the user if the confirm closing the page.
+  }
+
+  setLocation(wikiConfig: WikiConfig): void {
+    window.localStorage.setItem("currentApp", wikiConfig.name);
+    browserElectron.setStorageRoot(wikiConfig.storageRoot);
   }
 }

--- a/electron/browser/src/electron/main/index.ts
+++ b/electron/browser/src/electron/main/index.ts
@@ -18,6 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
+import { setStorageRoot as stateSetStorageRoot } from "@xwiki/cristal-electron-state";
 import { app, ipcMain } from "electron";
 import { resolve } from "node:path";
 import BrowserWindow = Electron.BrowserWindow;
@@ -30,8 +31,15 @@ function reloadBrowser(window: BrowserWindow) {
   window.loadFile(resolve(app.getAppPath(), "./renderer/dist/index.html"));
 }
 
+function setStorageRoot(storageRoot?: string): void {
+  stateSetStorageRoot(storageRoot);
+}
+
 export default function load(window: BrowserWindow): void {
   ipcMain.handle("reloadBrowser", () => {
     return reloadBrowser(window);
+  });
+  ipcMain.handle("setStorageRoot", (_event, { storageRoot }) => {
+    return setStorageRoot(storageRoot);
   });
 }

--- a/electron/browser/src/electron/preload/index.ts
+++ b/electron/browser/src/electron/preload/index.ts
@@ -25,5 +25,8 @@ const api: APITypes = {
   reloadBrowser() {
     return ipcRenderer.invoke("reloadBrowser", {});
   },
+  setStorageRoot(storageRoot?: string) {
+    return ipcRenderer.invoke("setStorageRoot", { storageRoot });
+  },
 };
 contextBridge.exposeInMainWorld("browserElectron", api);

--- a/electron/state/package.json
+++ b/electron/state/package.json
@@ -1,0 +1,41 @@
+{
+  "name": "@xwiki/cristal-electron-state",
+  "version": "0.15.0",
+  "license": "LGPL 2.1",
+  "author": "XWiki Org Community <contact@xwiki.org>",
+  "homepage": "https://cristal.xwiki.org/",
+  "repository": {
+    "type": "git",
+    "directory": "electron/state",
+    "url": "https://github.com/xwiki-contrib/cristal/"
+  },
+  "bugs": {
+    "url": "https://jira.xwiki.org/projects/CRISTAL/"
+  },
+  "type": "module",
+  "exports": {
+    ".": "./src/index.ts"
+  },
+  "main": "./src/index.ts",
+  "scripts": {
+    "build": "tsc --project tsconfig.json && vite build",
+    "clean": "rimraf dist",
+    "lint": "eslint \"./src/**/*.{ts,tsx,vue}\" --max-warnings=0"
+  },
+  "devDependencies": {
+    "@xwiki/cristal-dev-config": "workspace:*",
+    "typescript": "5.8.2",
+    "vite": "6.2.2"
+  },
+  "publishConfig": {
+    "exports": {
+      ".": {
+        "import": "./dist/index.es.js",
+        "require": "./dist/index.umd.js",
+        "types": "./dist/index.d.ts"
+      }
+    },
+    "main": "./dist/index.es.js",
+    "types": "./dist/index.d.ts"
+  }
+}

--- a/electron/state/src/index.ts
+++ b/electron/state/src/index.ts
@@ -22,10 +22,20 @@ const storedConfig: {
   storageRoot?: string;
 } = {};
 
+/**
+ * Set the storage root location for the current configuration.
+ * @param storageRoot - the new storage root location
+ * @since 0.16
+ */
 function setStorageRoot(storageRoot?: string): void {
   storedConfig.storageRoot = storageRoot;
 }
 
+/**
+ * Get the storage root location for the current configuration.
+ * @returns the current storage root location
+ * @since 0.16
+ */
 function getStorageRoot(): string | undefined {
   return storedConfig.storageRoot;
 }

--- a/electron/state/src/index.ts
+++ b/electron/state/src/index.ts
@@ -18,7 +18,16 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-export interface APITypes {
-  reloadBrowser(): void;
-  setStorageRoot(storageRoot?: string): void;
+const storedConfig: {
+  storageRoot?: string;
+} = {};
+
+function setStorageRoot(storageRoot?: string): void {
+  storedConfig.storageRoot = storageRoot;
 }
+
+function getStorageRoot(): string | undefined {
+  return storedConfig.storageRoot;
+}
+
+export { getStorageRoot, setStorageRoot };

--- a/electron/state/tsconfig.json
+++ b/electron/state/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "extends": "./../../tsconfig.json",
+  "include": [
+    "./src/index.ts",
+    "./src/**/*"
+  ],
+  "exclude": [
+    "**/*.spec.ts",
+    "**/*.test.ts"
+  ]
+}

--- a/electron/state/tsdoc.json
+++ b/electron/state/tsdoc.json
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+  "extends": ["../../tsdoc.json"]
+}

--- a/electron/state/vite.config.js
+++ b/electron/state/vite.config.js
@@ -18,7 +18,6 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-export interface APITypes {
-  reloadBrowser(): void;
-  setStorageRoot(storageRoot?: string): void;
-}
+import { generateConfig } from "../../vite.config";
+
+export default generateConfig(import.meta.url);

--- a/electron/storage/package.json
+++ b/electron/storage/package.json
@@ -30,6 +30,7 @@
   "dependencies": {
     "@xwiki/cristal-api": "workspace:*",
     "@xwiki/cristal-backend-api": "workspace:*",
+    "@xwiki/cristal-electron-state": "workspace:*",
     "@xwiki/cristal-link-suggest-api": "workspace:*",
     "@xwiki/cristal-model-api": "workspace:*",
     "@xwiki/cristal-model-remote-url-filesystem-api": "workspace:*",

--- a/electron/storage/src/components/FileSystemConfig.ts
+++ b/electron/storage/src/components/FileSystemConfig.ts
@@ -18,9 +18,12 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
+import { APITypes } from "../electron/preload/apiTypes";
 import { DefaultWikiConfig } from "@xwiki/cristal-api";
 import { inject, injectable, named } from "inversify";
 import type { CristalApp, Logger, Storage } from "@xwiki/cristal-api";
+
+declare const fileSystemStorage: APITypes;
 
 @injectable()
 export class FileSystemConfig extends DefaultWikiConfig {
@@ -42,5 +45,12 @@ export class FileSystemConfig extends DefaultWikiConfig {
 
   override getType(): string {
     return "FileSystem";
+  }
+
+  override initialize(): void {
+    super.initialize();
+    // The initialization for the root directory needs to be done after a
+    // configuration change, but before any storage operation.
+    fileSystemStorage.initRootDirectory();
   }
 }

--- a/electron/storage/src/electron/main/index.ts
+++ b/electron/storage/src/electron/main/index.ts
@@ -34,6 +34,8 @@ const HOME_PATH = ".cristal";
 const HOME_PATH_FULL = join(app.getPath("home"), HOME_PATH);
 
 function getHomePathFull(): string {
+  // If no custom storage root was provided in the current configuration, we
+  // fallback to the folder `${HOME}/.cristal`.
   return getStorageRoot() ?? HOME_PATH_FULL;
 }
 

--- a/electron/storage/src/electron/main/index.ts
+++ b/electron/storage/src/electron/main/index.ts
@@ -19,6 +19,7 @@
  */
 
 import { PageAttachment, PageData } from "@xwiki/cristal-api";
+import { getStorageRoot } from "@xwiki/cristal-electron-state";
 import { LinkType } from "@xwiki/cristal-link-suggest-api";
 import { EntityType } from "@xwiki/cristal-model-api";
 import { protocol as cristalFSProtocol } from "@xwiki/cristal-model-remote-url-filesystem-api";
@@ -32,9 +33,12 @@ import { basename, dirname, join, relative } from "node:path";
 const HOME_PATH = ".cristal";
 const HOME_PATH_FULL = join(app.getPath("home"), HOME_PATH);
 
+function getHomePathFull(): string {
+  return getStorageRoot() ?? HOME_PATH_FULL;
+}
+
 function resolvePath(page: string, ...lastSegments: string[]) {
-  const homedir = app.getPath("home");
-  return join(homedir, HOME_PATH, page, ...lastSegments);
+  return join(getHomePathFull(), page, ...lastSegments);
 }
 
 function resolvePagePath(page: string): string {
@@ -117,8 +121,9 @@ async function pathExists(path: string) {
 async function readPage(
   path: string,
 ): Promise<{ type: EntityType.DOCUMENT; value: PageData } | undefined> {
-  if (!(await isWithin(HOME_PATH_FULL, path))) {
-    throw new Error(`[${path}] is not in in [${HOME_PATH_FULL}]`);
+  const homePathFull = getHomePathFull();
+  if (!(await isWithin(homePathFull, path))) {
+    throw new Error(`[${path}] is not in in [${homePathFull}]`);
   }
   if (await isFile(path)) {
     const pageContent = await fs.promises.readFile(path);
@@ -130,7 +135,7 @@ async function readPage(
         ...parse,
         lastAuthor: { name: os.userInfo().username },
         lastModificationDate: new Date(pageStats.mtimeMs),
-        id: relative(HOME_PATH_FULL, dirname(path)),
+        id: relative(homePathFull, dirname(path)),
         canEdit: true,
       },
     };
@@ -142,8 +147,9 @@ async function readPage(
 async function readAttachments(
   path: string,
 ): Promise<PageAttachment[] | undefined> {
-  if (!(await isWithin(HOME_PATH_FULL, path))) {
-    throw new Error(`[${path}] is not in in [${HOME_PATH_FULL}]`);
+  const homePathFull = getHomePathFull();
+  if (!(await isWithin(homePathFull, path))) {
+    throw new Error(`[${path}] is not in in [${homePathFull}]`);
   }
   if (await isDirectory(path)) {
     const attachments = await fs.promises.readdir(path);
@@ -162,8 +168,9 @@ async function readAttachments(
 async function readAttachment(
   path: string,
 ): Promise<{ type: EntityType.ATTACHMENT; value: PageAttachment } | undefined> {
-  if (!(await isWithin(HOME_PATH_FULL, path))) {
-    throw new Error(`[${path}] is not in in [${HOME_PATH_FULL}]`);
+  const homePathFull = getHomePathFull();
+  if (!(await isWithin(homePathFull, path))) {
+    throw new Error(`[${path}] is not in in [${homePathFull}]`);
   }
 
   if (await isFile(path)) {
@@ -174,8 +181,8 @@ async function readAttachment(
       value: {
         id: basename(path),
         mimetype,
-        reference: relative(HOME_PATH_FULL, path),
-        href: `${cristalFSProtocol}://${relative(HOME_PATH_FULL, path)}`,
+        reference: relative(homePathFull, path),
+        href: `${cristalFSProtocol}://${relative(homePathFull, path)}`,
         date: stats.mtime,
         size: stats.size,
         author: undefined,
@@ -207,8 +214,9 @@ async function savePage(
   content: string,
   title: string,
 ): Promise<PageData | undefined> {
-  if (!(await isWithin(HOME_PATH_FULL, path))) {
-    throw new Error(`[${path}] is not in in [${HOME_PATH_FULL}]`);
+  const homePathFull = getHomePathFull();
+  if (!(await isWithin(homePathFull, path))) {
+    throw new Error(`[${path}] is not in in [${homePathFull}]`);
   }
   let jsonContent: {
     source: string;
@@ -240,8 +248,9 @@ async function savePage(
 }
 
 async function saveAttachment(path: string, filePath: string) {
-  if (!(await isWithin(HOME_PATH_FULL, path))) {
-    throw new Error(`[${path}] is not in in [${HOME_PATH_FULL}]`);
+  const homePathFull = getHomePathFull();
+  if (!(await isWithin(homePathFull, path))) {
+    throw new Error(`[${path}] is not in in [${homePathFull}]`);
   }
   const parentDirectory = dirname(path);
 
@@ -303,8 +312,9 @@ async function search(
     | { type: EntityType.DOCUMENT; value: PageData }
   )[]
 > {
-  const attachments = (await readdir(HOME_PATH_FULL, { recursive: true })).map(
-    (it) => join(HOME_PATH_FULL, it),
+  const homePathFull = getHomePathFull();
+  const attachments = (await readdir(homePathFull, { recursive: true })).map(
+    (it) => join(homePathFull, it),
   );
   const allEntities = await asyncFilter(attachments, async (path: string) => {
     if (type == LinkType.ATTACHMENT) {
@@ -345,7 +355,7 @@ async function search(
  */
 async function createMinimalContent() {
   await savePage(
-    join(HOME_PATH_FULL, "index", "page.json"),
+    join(getHomePathFull(), "index", "page.json"),
     "# Welcome\n" +
       "\n" +
       "This is a new **Cristal** wiki.\n" +
@@ -450,7 +460,7 @@ async function movePageSingle(path: string, newPath: string) {
  * @since 0.14
  */
 async function cleanEmptyArborescence(directory: string): Promise<void> {
-  if (await isWithin(HOME_PATH_FULL, directory)) {
+  if (await isWithin(getHomePathFull(), directory)) {
     if (!(await pathExists(directory))) {
       await cleanEmptyArborescence(dirname(directory));
     } else if ((await isDirectory(directory)) && (await isEmpty(directory))) {
@@ -463,22 +473,26 @@ async function cleanEmptyArborescence(directory: string): Promise<void> {
 // TODO: reduce the number of statements in the following method and reactivate the disabled eslint rule.
 // eslint-disable-next-line max-statements
 export default async function load(): Promise<void> {
-  // Check if the root directory does not exist, or exists and is empty.
-  // If that's the case, create it and populate it with a default minimal content.
-  if (
-    !(await pathExists(HOME_PATH_FULL)) ||
-    ((await isDirectory(HOME_PATH_FULL)) && (await isEmpty(HOME_PATH_FULL)))
-  ) {
-    await createMinimalContent();
-  }
+  ipcMain.on("initRootDirectory", async () => {
+    // Check if the root directory does not exist, or exists and is empty.
+    // If that's the case, create it and populate it with a default minimal content.
+    const homePathFull = getHomePathFull();
+    if (
+      !(await pathExists(homePathFull)) ||
+      ((await isDirectory(homePathFull)) && (await isEmpty(homePathFull)))
+    ) {
+      await createMinimalContent();
+    }
+  });
 
   protocol.handle(cristalFSProtocol, async (request) => {
+    const homePathFull = getHomePathFull();
     const path = join(
-      HOME_PATH_FULL,
+      homePathFull,
       request.url.substring(`${cristalFSProtocol}://`.length),
     );
-    if (!(await isWithin(HOME_PATH_FULL, path))) {
-      throw new Error(`[${path}] is not in in [${HOME_PATH_FULL}]`);
+    if (!(await isWithin(homePathFull, path))) {
+      throw new Error(`[${path}] is not in in [${homePathFull}]`);
     }
     return net.fetch(`file://${path}`);
   });

--- a/electron/storage/src/electron/preload/apiTypes.ts
+++ b/electron/storage/src/electron/preload/apiTypes.ts
@@ -23,6 +23,8 @@ import { LinkType } from "@xwiki/cristal-link-suggest-api";
 import { EntityType } from "@xwiki/cristal-model-api";
 
 export interface APITypes {
+  initRootDirectory(): void;
+
   resolvePath(page: string): Promise<string>;
 
   resolveAttachmentsPath(page: string): Promise<string>;

--- a/electron/storage/src/electron/preload/index.ts
+++ b/electron/storage/src/electron/preload/index.ts
@@ -25,6 +25,9 @@ import { EntityType } from "@xwiki/cristal-model-api";
 import { contextBridge, ipcRenderer, webUtils } from "electron";
 
 const api: APITypes = {
+  initRootDirectory(): void {
+    return ipcRenderer.send("initRootDirectory", {});
+  },
   readPage: (path: string) => {
     return ipcRenderer.invoke("readPage", { path });
   },

--- a/lib/src/components/DefaultCristalApp.ts
+++ b/lib/src/components/DefaultCristalApp.ts
@@ -137,6 +137,7 @@ export class DefaultCristalApp implements CristalApp {
 
   setWikiConfig(wikiConfig: WikiConfig): void {
     this.wikiConfig = wikiConfig;
+    this.browserApi.setLocation(wikiConfig);
   }
 
   getWikiConfig(): WikiConfig {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3375,6 +3375,9 @@ importers:
       '@xwiki/cristal-browser-api':
         specifier: workspace:*
         version: link:../../core/browser/browser-api
+      '@xwiki/cristal-electron-state':
+        specifier: workspace:*
+        version: link:../state
       electron:
         specifier: 35.0.1
         version: 35.0.1
@@ -3615,6 +3618,18 @@ importers:
         specifier: 6.2.2
         version: 6.2.2(@types/node@22.13.10)(tsx@4.19.3)(yaml@2.7.0)
 
+  electron/state:
+    devDependencies:
+      '@xwiki/cristal-dev-config':
+        specifier: workspace:*
+        version: link:../../dev/config
+      typescript:
+        specifier: 5.8.2
+        version: 5.8.2
+      vite:
+        specifier: 6.2.2
+        version: 6.2.2(@types/node@22.13.10)(tsx@4.19.3)(yaml@2.7.0)
+
   electron/storage:
     dependencies:
       '@xwiki/cristal-api':
@@ -3623,6 +3638,9 @@ importers:
       '@xwiki/cristal-backend-api':
         specifier: workspace:*
         version: link:../../core/backends/backend-api
+      '@xwiki/cristal-electron-state':
+        specifier: workspace:*
+        version: link:../state
       '@xwiki/cristal-link-suggest-api':
         specifier: workspace:*
         version: link:../../core/link-suggest/link-suggest-api

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -61,6 +61,7 @@ packages:
   - "electron/preload"
   - "electron/renderer"
   - "electron/storage"
+  - "electron/state"
   - "electron/browser"
   - "electron/configuration/configuration-electron/*"
   - "electron/link-suggest/*"


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-496

# Changes

## Description

This PR adds support for the `storageRoot` configuration key to the FileSystem backend.

## Clarifications

The `storageRoot` value needs to be made available to the main process of electron. In order to do this, a state package was created at `electron/state` to set and get this information.
BrowserApi and its Electron implementation were slightly refactored to handle that.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
The test suite was run locally.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A