### PR TITLE
Fix: missing toolbar for most block types in BlockNote

### DIFF
--- a/editors/blocknote-headless/src/vue/c-blocknote-view.vue
+++ b/editors/blocknote-headless/src/vue/c-blocknote-view.vue
@@ -160,7 +160,21 @@ const initializedEditorProps: Omit<
   "content"
 > = {
   ...editorProps,
-  prefixDefaultFormattingToolbarFor: ["paragraph"],
+  prefixDefaultFormattingToolbarFor: [
+    "paragraph",
+    "BlockQuote",
+    "heading",
+    "Heading4",
+    "Heading5",
+    "Heading6",
+    "bulletListItem",
+    "checkListItem",
+    "numberedListItem",
+    "column",
+    "columnList",
+    "codeBlock",
+    "table",
+  ],
   blockNoteOptions: {
     ...editorProps.blockNoteOptions,
     collaboration,
@@ -217,7 +231,12 @@ const { t } = useI18n({
         :link-edition-ctx
       />
 
-      <strong v-else>Unknown block type: {{ currentBlock.type }}</strong>
+      <!--
+        NOTE: This is the expected behaviour once we've implemented a custom toolbar for **ALL** block types
+        In the meantime, we'll keep using BlockNote's default toolbar when we don't have our own one
+      -->
+
+      <!--<strong v-else>Unknown block type: {{ currentBlock.type }}</strong>-->
     </template>
 
     <!-- Custom (popover) toolbar for link edition -->


### PR DESCRIPTION
# Jira URL

N/A

# Changes

## Description

* Restored missing toolbar on most block types in BlockNote editor

## Clarifications

* An error is shown when a custom toolbar is missing for a particular block type. But, as we did not implement a custom toolbar for all elements yet, this error is shown for most block types such as tables, lists, block quotes, code blocks, some headings, etc.

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A