### PR TITLE
CRISTAL-514: Enable creating pages with BlockNote

### DIFF
--- a/api/src/api/cristalApp.ts
+++ b/api/src/api/cristalApp.ts
@@ -76,7 +76,8 @@ export interface CristalApp {
    */
   getCurrentSyntax(): string;
 
-  setCurrentPage(page: string, mode?: string): void;
+  /** @since 0.18 */
+  setCurrentPage(page: string, mode?: string): Promise<void>;
 
   /**
    * @deprecated use the document-api instead

--- a/core/backends/backend-github/src/githubStorage.ts
+++ b/core/backends/backend-github/src/githubStorage.ts
@@ -210,7 +210,7 @@ export class GitHubStorage extends AbstractStorage {
     return "";
   }
 
-  async save(page: string, content: string, title: string): Promise<unknown> {
+  async save(page: string, title: string, content: string): Promise<unknown> {
     const pageRestUrl = this.getPageRestURL(`${page}/page.json`, "");
 
     const headResponse = await fetch(pageRestUrl, {

--- a/core/backends/backend-nextcloud/src/nextcloudStorage.ts
+++ b/core/backends/backend-nextcloud/src/nextcloudStorage.ts
@@ -245,7 +245,7 @@ export class NextcloudStorage extends AbstractStorage {
     return `${this.getAttachmentsBasePath(page, username)}/${name}`;
   }
 
-  async save(page: string, content: string, title: string): Promise<unknown> {
+  async save(page: string, title: string, content: string): Promise<unknown> {
     const username = (
       await this.authenticationManagerProvider.get()?.getUserDetails()
     )?.username;

--- a/core/backends/backend-xwiki/src/xwikiStorage.ts
+++ b/core/backends/backend-xwiki/src/xwikiStorage.ts
@@ -304,7 +304,7 @@ export class XWikiStorage extends AbstractStorage {
     }
   }
 
-  async save(page: string, content: string, title: string): Promise<unknown> {
+  async save(page: string, title: string, content: string): Promise<unknown> {
     const url = this.buildSavePageURL(page, ["rest", "wikis", "xwiki"]);
 
     const response = await fetch(url, {

--- a/core/document/document-api/src/index.ts
+++ b/core/document/document-api/src/index.ts
@@ -88,13 +88,20 @@ interface DocumentService {
    * Update the reference of the latest document.
    * @param documentReference - the current document reference
    * @param revision - the revision of the document, undefined for latest
+   *
+   * @since 0.18
    */
-  setCurrentDocument(documentReference: string, revision?: string): void;
+  setCurrentDocument(
+    documentReference: string,
+    revision?: string,
+  ): Promise<void>;
 
   /**
    * Force reloading the content of the document without changing the current document reference
+   *
+   * @since 0.18
    */
-  refreshCurrentDocument(): void;
+  refreshCurrentDocument(): Promise<void>;
 
   /**
    * Register a change listener that will be executed on any document change

--- a/core/document/document-default/src/defaultDocumentService.ts
+++ b/core/document/document-default/src/defaultDocumentService.ts
@@ -227,16 +227,24 @@ export class DefaultDocumentService implements DocumentService {
     return this.refs.error;
   }
 
-  setCurrentDocument(documentReference: string, revision?: string): void {
+  async setCurrentDocument(
+    documentReference: string,
+    revision?: string,
+  ): Promise<void> {
     if (this.store) {
-      this.store.update(documentReference, true, revision);
+      await this.store.update(documentReference, true, revision);
     }
   }
 
-  refreshCurrentDocument(): void {
+  async refreshCurrentDocument(): Promise<void> {
     const documentReference = this.store.lastDocumentReference;
+
     if (documentReference) {
-      this.store.update(documentReference, false, this.store.lastRevision);
+      await this.store.update(
+        documentReference,
+        false,
+        this.store.lastRevision,
+      );
     }
   }
 

--- a/core/page-actions/page-actions-ui/src/vue/MovePage.vue
+++ b/core/page-actions/page-actions-ui/src/vue/MovePage.vue
@@ -105,7 +105,7 @@ async function handleSuccess(result: { success: boolean; error?: string }) {
         props.currentPageReference,
       );
     }
-    cristal.setCurrentPage(newDocumentReferenceSerialized, "view");
+    await cristal.setCurrentPage(newDocumentReferenceSerialized, "view");
     alertsService.success(
       t("page.action.action.move.page.success", {
         page: props.currentPageName,

--- a/editors/blocknote/src/vue/c-edit-blocknote.vue
+++ b/editors/blocknote/src/vue/c-edit-blocknote.vue
@@ -63,8 +63,6 @@ const modelReferenceHandler = container
 const alertsService = container.get<AlertsService>("AlertsService")!;
 const storage = container.get<StorageProvider>("StorageProvider").get();
 
-console.warn([currentPageName, { ...currentPageReference }]);
-
 const { realtimeURL: realtimeServerURL } = cristal.getWikiConfig();
 
 const title = ref("");

--- a/editors/blocknote/src/vue/c-edit-blocknote.vue
+++ b/editors/blocknote/src/vue/c-edit-blocknote.vue
@@ -63,6 +63,8 @@ const modelReferenceHandler = container
 const alertsService = container.get<AlertsService>("AlertsService")!;
 const storage = container.get<StorageProvider>("StorageProvider").get();
 
+console.warn([currentPageName, { ...currentPageReference }]);
+
 const { realtimeURL: realtimeServerURL } = cristal.getWikiConfig();
 
 const title = ref("");
@@ -152,8 +154,8 @@ async function save(content: string) {
     // TODO: html does not make any sense here.
     await storage.save(
       currentPageName.value ?? "",
-      content,
       title.value,
+      content,
       "html",
     );
   } catch (e) {
@@ -161,13 +163,6 @@ async function save(content: string) {
     console.error(e);
     alertsService.error(t("blocknote.editor.save.error"));
   }
-
-  // If this save operation just created the document, the current document
-  // will be undefined. So we update it.
-  if (!currentPage.value) {
-    documentService.setCurrentDocument(currentPageName.value ?? "");
-  }
-  documentService.notifyDocumentChange("update", currentPageReference.value!);
 }
 
 watch(

--- a/editors/tiptap/src/vue/c-edit-tiptap.vue
+++ b/editors/tiptap/src/vue/c-edit-tiptap.vue
@@ -76,7 +76,7 @@ const { t } = useI18n({
   messages,
 });
 
-const cristal: CristalApp = inject<CristalApp>("cristal")!;
+const cristal = inject<CristalApp>("cristal")!;
 
 const container = cristal.getContainer();
 const documentService = container.get<DocumentService>(documentServiceName);
@@ -130,6 +130,7 @@ const { update } = initOnQuitHelper(
   cristal.getRouter(),
   browserApi,
 );
+
 const updateOnQuitContent: () => void = update;
 
 function getEditorMarkdown() {
@@ -143,8 +144,8 @@ const save = async () => {
     // TODO: html does not make any sense here.
     await storage.save(
       currentPageName.value ?? "",
-      getEditorMarkdown(),
       title.value,
+      getEditorMarkdown(),
       "html",
     );
     // Update the on quit content with the last successfully saved content.
@@ -156,13 +157,9 @@ const save = async () => {
     alertsService.error(t("tiptap.editor.save.error"));
   }
 
-  // If this save operation just created the document, the current document
-  // will be undefined. So we update it.
-  if (!currentPage.value) {
-    documentService.setCurrentDocument(currentPageName.value ?? "");
-  }
   documentService.notifyDocumentChange("update", currentPageReference.value!);
 };
+
 const submit = async () => {
   if (!hasRealtime) {
     await save();

--- a/electron/storage/src/components/fileSystemStorage.ts
+++ b/electron/storage/src/components/fileSystemStorage.ts
@@ -88,9 +88,9 @@ export default class FileSystemStorage extends AbstractStorage {
     return Promise.resolve(true);
   }
 
-  async save(page: string, content: string, title: string): Promise<void> {
+  async save(page: string, title: string, content: string): Promise<void> {
     const path = await fileSystemStorage.resolvePath(page);
-    await fileSystemStorage.savePage(path, content, title);
+    await fileSystemStorage.savePage(path, title, content);
   }
 
   async saveAttachments(page: string, files: File[]): Promise<unknown> {

--- a/electron/storage/src/components/fileSystemStorage.ts
+++ b/electron/storage/src/components/fileSystemStorage.ts
@@ -90,7 +90,7 @@ export default class FileSystemStorage extends AbstractStorage {
 
   async save(page: string, title: string, content: string): Promise<void> {
     const path = await fileSystemStorage.resolvePath(page);
-    await fileSystemStorage.savePage(path, title, content);
+    await fileSystemStorage.savePage(path, content, title);
   }
 
   async saveAttachments(page: string, files: File[]): Promise<unknown> {

--- a/electron/storage/src/electron/preload/apiTypes.ts
+++ b/electron/storage/src/electron/preload/apiTypes.ts
@@ -37,7 +37,7 @@ export interface APITypes {
 
   readAttachment(path: string): Promise<PageAttachment>;
 
-  savePage(path: string, title: string, content: string): Promise<PageData>;
+  savePage(path: string, content: string, title: string): Promise<PageData>;
 
   saveAttachment(path: string, file: File): Promise<PageData>;
 

--- a/electron/storage/src/electron/preload/apiTypes.ts
+++ b/electron/storage/src/electron/preload/apiTypes.ts
@@ -37,7 +37,7 @@ export interface APITypes {
 
   readAttachment(path: string): Promise<PageAttachment>;
 
-  savePage(path: string, content: string, title: string): Promise<PageData>;
+  savePage(path: string, title: string, content: string): Promise<PageData>;
 
   saveAttachment(path: string, file: File): Promise<PageData>;
 

--- a/electron/storage/src/electron/preload/index.ts
+++ b/electron/storage/src/electron/preload/index.ts
@@ -45,8 +45,8 @@ const api: APITypes = {
       page: page || "index",
     });
   },
-  savePage(path: string, content: string, title: string): Promise<PageData> {
-    return ipcRenderer.invoke("savePage", { path, content, title });
+  savePage(path: string, title: string, content: string): Promise<PageData> {
+    return ipcRenderer.invoke("savePage", { path, title, content });
   },
   resolveAttachmentPath(page: string, filename: string): Promise<string> {
     return ipcRenderer.invoke("resolveAttachmentPath", {

--- a/electron/storage/src/electron/preload/index.ts
+++ b/electron/storage/src/electron/preload/index.ts
@@ -45,7 +45,7 @@ const api: APITypes = {
       page: page || "index",
     });
   },
-  savePage(path: string, title: string, content: string): Promise<PageData> {
+  savePage(path: string, content: string, title: string): Promise<PageData> {
     return ipcRenderer.invoke("savePage", { path, title, content });
   },
   resolveAttachmentPath(page: string, filename: string): Promise<string> {

--- a/lib/src/components/DefaultCristalApp.ts
+++ b/lib/src/components/DefaultCristalApp.ts
@@ -119,8 +119,8 @@ export class DefaultCristalApp implements CristalApp {
     return this.page.name || this.wikiConfig.defaultPageName();
   }
 
-  setCurrentPage(newPage: string, mode: string = "view"): void {
-    this.router.push({
+  async setCurrentPage(newPage: string, mode: string = "view"): Promise<void> {
+    await this.router.push({
       name: mode,
       params: { page: newPage },
     });
@@ -234,9 +234,15 @@ export class DefaultCristalApp implements CristalApp {
   async loadPage(options?: { requeue: boolean }): Promise<void> {
     try {
       this.logger?.debug("Loading page", this.page.name);
+
       const documentService =
         this.getContainer().get<DocumentService>(documentServiceName);
-      documentService.setCurrentDocument(this.page.name, this.page.version);
+
+      await documentService.setCurrentDocument(
+        this.page.name,
+        this.page.version,
+      );
+
       if (this.getWikiConfig().isSupported("jsonld")) {
         const pageData = await this.getWikiConfig().storage.getPageContent(
           this.page.name,
@@ -328,7 +334,7 @@ export class DefaultCristalApp implements CristalApp {
     const page = this.getWikiConfig().storage.getPageFromViewURL(url);
     if (page != null) {
       this.logger?.debug("The link is evaluated as being page ", page);
-      this.setCurrentPage(page);
+      await this.setCurrentPage(page);
     } else {
       this.logger?.debug("The link is evaluated as an external link");
       window.open(url, "_blank");

--- a/sharedworker/impl/src/components/defaultQueueWorker.ts
+++ b/sharedworker/impl/src/components/defaultQueueWorker.ts
@@ -43,7 +43,7 @@ export default class DefaultQueueWorker implements QueueWorker {
     this.cristalApp = cristalApp;
   }
 
-  public pageLoaded(page: string): void {
+  async pageLoaded(page: string): Promise<void> {
     try {
       this.logger.debug(
         "Received callback that new document has been loaded",
@@ -54,7 +54,8 @@ export default class DefaultQueueWorker implements QueueWorker {
       const documentService = this.cristalApp
         .getContainer()
         .get<DocumentService>(documentServiceName);
-      documentService.refreshCurrentDocument();
+
+      await documentService.refreshCurrentDocument();
 
       this.logger.debug(
         "Done callback that new document has been loaded",
@@ -77,9 +78,10 @@ export default class DefaultQueueWorker implements QueueWorker {
         // TODO get rid of aliasing
         // eslint-disable-next-line @typescript-eslint/no-this-alias
         const that = this;
+
         this.workerInstance.setPageLoadedCallback(
-          Comlink.proxy(function (page: string) {
-            that.pageLoaded(page);
+          Comlink.proxy(async (page: string) => {
+            await that.pageLoaded(page);
           }),
         );
 

--- a/sharedworker/impl/src/components/workerCristalApp.ts
+++ b/sharedworker/impl/src/components/workerCristalApp.ts
@@ -123,7 +123,7 @@ export class WorkerCristalApp implements CristalApp {
     throw new Error("Method not implemented.");
   }
 
-  setCurrentPage(): void {
+  setCurrentPage(): Promise<void> {
     throw new Error("Method not implemented.");
   }
 

--- a/skin/src/vue/c-document-refresher.vue
+++ b/skin/src/vue/c-document-refresher.vue
@@ -1,0 +1,60 @@
+<!--
+See the LICENSE file distributed with this work for additional
+information regarding copyright ownership.
+
+This is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2.1 of
+the License, or (at your option) any later version.
+
+This software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this software; if not, write to the Free
+Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301 USA, or see the FSF site: http://www.fsf.org.
+-->
+<script setup lang="ts">
+import { CristalApp } from "@xwiki/cristal-api";
+import { DocumentService } from "@xwiki/cristal-document-api";
+import { DocumentReference } from "@xwiki/cristal-model-api";
+import { ModelReferenceSerializerProvider } from "@xwiki/cristal-model-reference-api";
+import { inject, onMounted, shallowRef } from "vue";
+
+defineSlots<{
+  default: [];
+}>();
+
+const cristal = inject<CristalApp>("cristal")!;
+
+const container = cristal.getContainer();
+
+const documentService = container.get<DocumentService>("DocumentService")!;
+
+const modelReferenceSerializer = container
+  .get<ModelReferenceSerializerProvider>("ModelReferenceSerializerProvider")
+  .get()!;
+
+function computeDocumentRef(documentRef: DocumentReference): string {
+  return modelReferenceSerializer.serialize(documentRef)!;
+}
+
+const initialDoc = documentService.getCurrentDocumentReference();
+
+const documentId = shallowRef<string>(
+  initialDoc.value ? computeDocumentRef(initialDoc.value) : "",
+);
+
+onMounted(() => {
+  documentService.registerDocumentChangeListener("update", async (ref) => {
+    documentId.value = computeDocumentRef(ref);
+  });
+});
+</script>
+
+<template>
+  <slot :key="documentId" />
+</template>

--- a/skin/src/vue/c-edit.vue
+++ b/skin/src/vue/c-edit.vue
@@ -44,6 +44,12 @@ const component = markRaw(editComponent);
 </script>
 
 <template>
+  <!-- When the user is on an edit page with the editor displayed, and a new page is created, the editor is not refreshed.
+       Due lots of state variables in the editor component, it is arguably preferable to refresh the entire component to make it aware of the new document.
+
+      Ths <CDocumentRefresher> component helps with that: the c-edit component, which is in charge of displaying the selected editor, watches the current document.
+      When it changes, the underlying editor component is un-mounted then re-mounted using Vue's builtin key mechanism, which forces re-mounting.
+  -->
   <CDocumentRefresher>
     <component :is="component" />
   </CDocumentRefresher>

--- a/skin/src/vue/c-edit.vue
+++ b/skin/src/vue/c-edit.vue
@@ -18,6 +18,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 02110-1301 USA, or see the FSF site: http://www.fsf.org.
 -->
 <script setup lang="ts">
+import CDocumentRefresher from "./c-document-refresher.vue";
 import { CristalApp } from "@xwiki/cristal-api";
 import { inject, markRaw } from "vue";
 
@@ -43,5 +44,7 @@ const component = markRaw(editComponent);
 </script>
 
 <template>
-  <component :is="component" />
+  <CDocumentRefresher>
+    <component :is="component" />
+  </CDocumentRefresher>
 </template>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-514

# Changes

## Description

* Enables creating pages with the BlockNote editor

## Clarifications

This PR is very heavy as it contains a lot of changes necessary for proper page creation instead of just "bruteforcing". The current (previous) way of creating pages (with TipTap) is as follows!

1. When the new page name is submitted, the page is not actually created
2. The router navigates to the edit page and loads TipTap
3. TipTap sees the page is not defined, and creates it with an empty content

This is not only less than ideal as it makes the editor more complex (as it needs to handle non-existent documents) but also requires to duplicate this specific logic across all editor components.

This PR changes that ; the page is now created from within the modal, and _only after_ is the editor loaded.

## API problems

Some APIs have design problems, notably the order of some arguments are inconsistent between APIs. This has been fixed, which makes it a breaking change PR. The APIs for saving documents are now consistent.

Also, some APIs were performing asynchronous work and incorrectly returning synchronously before their task was completed. This has been fixed too, and required changing some signatures.

## Document changing when the editor is displaying

One bug which arose with this method is that when the user is on an edit page with the editor displayed, and a new page is created, the editor is not refreshed. And due to having lots of state variables, it is arguably preferable to refresh the entire component to make it aware of the new document.

The `c-document-refresher.vue` component helps with that: the `c-edit` component, which is in charge of displaying the selected editor, watches the current document. When it changes, the underlying editor component is un-mounted then re-mounted using Vue's builtin `key` mechanism, which forces re-mounting.

## Misc

While this is out of the scope of this PR, working on this task highlighted additional problems with NX as a workspace manager. Multiple changes in the codebase were not registered by NX (even though file watchers seem to be behaving correctly) which resulted in time loss during bug isolation. Reducing a code portion to its strict minimum to isolate a bug, and seeing the bug still appear during the reduction simply because NX didn't rebuild the project correctly is a problem. This should be investigated when time permits it.

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A