### PR TITLE
CRISTAL-535: Double scrollbars on Vuetify

### DIFF
--- a/ds/vuetify/src/vue/css/style.css
+++ b/ds/vuetify/src/vue/css/style.css
@@ -25,6 +25,10 @@
   height: 64px;
 }
 
+html {
+  overflow-y: auto;
+}
+
 main ul, main ol {
   padding-inline-start: var(--cr-spacing-x-large);
 }


### PR DESCRIPTION
* Added a Vuetify specific CSS rule to make the vertical scrollbar auto

# Jira URL

https://jira.xwiki.org/browse/CRISTAL-535

# Changes

## Description

* Just a simple rule to get rid of the extra space on Vuetify

## Clarifications

* 

# Screenshots & Video

Kind of hard to see, but the space on the right side of the Viewport is gone.

**Before:**
<img width="224" alt="Screenshot 2025-05-16 at 14 43 21" src="https://github.com/user-attachments/assets/7e8a8b82-b5cd-42e9-8240-d04ea42bfab5" />


**After:**
<img width="283" alt="Screenshot 2025-05-16 at 14 42 14" src="https://github.com/user-attachments/assets/b2bd6859-b488-4522-b6bf-7ed50abe29bd" />


# Executed Tests

-

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A