### PR TITLE
CRISTAL-516: BlockNote is not WYSIWYG

### DIFF
--- a/editors/blocknote-headless/src/vue/c-blocknote-view.vue
+++ b/editors/blocknote-headless/src/vue/c-blocknote-view.vue
@@ -328,11 +328,9 @@ const { t } = useI18n({
   }
 
   & [data-content-type="codeBlock"] {
-    /* background: var(--cr-color-neutral-100); */
     background: white;
     border-radius: var(--cr-border-radius-medium);
     font-family: var(--cr-font-mono);
-    /* padding: var(--cr-spacing-small); */
     color: var(--cr-base-text-color);
 
     & pre {

--- a/editors/blocknote-headless/src/vue/c-blocknote-view.vue
+++ b/editors/blocknote-headless/src/vue/c-blocknote-view.vue
@@ -308,6 +308,10 @@ const { t } = useI18n({
     font-size: var(--cr-font-size-medium);
   }
 
+  & [data-content-type="bulletListItem"] {
+    padding-inline-start: var(--cr-spacing-large);
+  }
+
   & blockquote {
     background-color: var(--cr-color-neutral-50);
     color: var(--cr-color-neutral-600);
@@ -318,10 +322,11 @@ const { t } = useI18n({
   }
 
   & [data-content-type="codeBlock"] {
-    background: var(--cr-color-neutral-100);
+    /* background: var(--cr-color-neutral-100); */
+    background: white;
     border-radius: var(--cr-border-radius-medium);
     font-family: var(--cr-font-mono);
-    padding: var(--cr-spacing-small);
+    /* padding: var(--cr-spacing-small); */
     color: var(--cr-base-text-color);
 
     & pre {

--- a/editors/blocknote-headless/src/vue/c-blocknote-view.vue
+++ b/editors/blocknote-headless/src/vue/c-blocknote-view.vue
@@ -273,4 +273,61 @@ const { t } = useI18n({
   border-radius: 6px;
   padding: 2px;
 }
+
+:deep(.bn-editor) {
+  font-family: var(--cr-font-sans);
+  font-size: var(--cr-base-font-size);
+  font-weight: var(--cr-font-weight-normal);
+  color: var(--cr-base-text-color);
+  letter-spacing: var(--cr-letter-spacing-normal);
+  line-height: var(--cr-line-height-normal);
+  padding-inline-start: var(--cr-spacing-large);
+
+  /* Note: font sizes are inconsistent here, but that's how they are rendered at the end. So we keep it the same here. */
+  & h1 {
+    font-size: var(--cr-font-size-x-large);
+  }
+
+  & h2 {
+    font-size: var(--cr-font-size-x-large);
+  }
+
+  & h3 {
+    font-size: var(--cr-font-size-large);
+  }
+
+  & h4 {
+    font-size: var(--cr-font-size-medium);
+  }
+
+  & h5 {
+    font-size: var(--cr-font-size-medium);
+  }
+
+  & h6 {
+    font-size: var(--cr-font-size-medium);
+  }
+
+  & blockquote {
+    background-color: var(--cr-color-neutral-50);
+    color: var(--cr-color-neutral-600);
+    font-size: var(--cr-font-size-large);
+    border-inline-start: 2px solid var(--cr-color-neutral-200);
+    padding-inline-start: var(--cr-spacing-large);
+    margin: 0;
+  }
+
+  & [data-content-type="codeBlock"] {
+    background: var(--cr-color-neutral-100);
+    border-radius: var(--cr-border-radius-medium);
+    font-family: var(--cr-font-mono);
+    padding: var(--cr-spacing-small);
+    color: var(--cr-base-text-color);
+
+    & pre {
+      margin: 0;
+      padding: 0;
+    }
+  }
+}
 </style>

--- a/editors/blocknote-headless/src/vue/c-blocknote-view.vue
+++ b/editors/blocknote-headless/src/vue/c-blocknote-view.vue
@@ -308,6 +308,12 @@ const { t } = useI18n({
     font-size: var(--cr-font-size-medium);
   }
 
+  /* Remove left border on lists */
+  & .bn-block-group,
+  .bn-block-group .bn-block-outer:not([data-prev-depth-changed])::before {
+    border-left: none;
+  }
+
   & [data-content-type="bulletListItem"] {
     padding-inline-start: var(--cr-spacing-large);
   }


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-516

# Changes

## Description

* Make BlockNote look more like rendered pages

## Clarifications

A lot of things to say on this one!

* I tried different approaches, and ended up with the simplest route: using CSS to override style inside the BlockNote's HTML editor elements
* All style elements (font names, sizes, paddings, margins, etc.) use variables imported from the current Design System. This means BlockNote's inner style will now adapt to the selected DS.
* Bullet lists' markers cannot be made the same size as the rendered pages because they are unaligned HTML elements, so increasing their size leads to this:
![image](https://github.com/user-attachments/assets/90e1cd28-204c-4920-96a5-38367d1dd117)
* Lists of tasks are not consistent with the rendered pages as this would be too complex to do. But given they are not supported in XWiki's rendered pages, no one should theorically use them.
* The look'n'feel is not consistent with TipTap, as TipTap itself is not consistent with the rendered pages
* The current implementation is not ideal as we rely on some undocumented BlockNote selectors to change the style. Even though these _should_ remain the same, this is not guaranteed by BlockNote's maintainers
* The style of the rendered page is not always coherent, for instance level 4/5/6 headings all have the same size. This behavior has been replicated here as to closely match the rendered pages, but this it something that should be changed in the future.

# Screenshots & Video

Rendered page:

![image](https://github.com/user-attachments/assets/647e4b8a-43c0-416b-a6f2-b1b20a9cbedf)

BlockNote:

![image](https://github.com/user-attachments/assets/3147b62a-6f43-4002-af72-357c9f1a79b4)

BlockNote **before** this PR:

![image](https://github.com/user-attachments/assets/b5ba93bc-5b35-449e-ab3e-b8188028bd5c)

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A