### PR TITLE
Make the editor syntax-agnostic

### DIFF
--- a/editors/blocknote-headless/src/vue/c-blocknote-view.vue
+++ b/editors/blocknote-headless/src/vue/c-blocknote-view.vue
@@ -43,11 +43,7 @@ import {
   ReactNonSlotProps,
   reactComponentAdapter,
 } from "@xwiki/cristal-reactivue";
-import {
-  UniAst,
-  UniAstToMarkdownConverter,
-  createConverterContext,
-} from "@xwiki/cristal-uniast";
+import { UniAst, createConverterContext } from "@xwiki/cristal-uniast";
 import { Container } from "inversify";
 
 import { debounce } from "lodash-es";
@@ -76,27 +72,18 @@ const {
 const editorRef = shallowRef<EditorType | null>(null);
 
 const emit = defineEmits<{
-  // TODO: the type of the content might change!
-  "blocknote-save": [content: string];
+  "blocknote-save": [content: UniAst];
 }>();
 
 defineExpose({
-  getContent: (): string | Error => extractEditorContent(),
+  getContent: (): UniAst | Error => extractEditorContent(),
 });
 
 /**
- * Extract the editor's content and convert it to Markdown
+ * Extract the editor's content and convert it to UniAst
  */
-function extractEditorContent(): string | Error {
-  const editor = editorRef.value!;
-  const uniAst = blockNoteToUniAst.blocksToUniAst(editor.document);
-
-  if (uniAst instanceof Error) {
-    // TODO: show proper error to user
-    throw uniAst;
-  }
-
-  return uniAstToMarkdown.toMarkdown(uniAst);
+function extractEditorContent(): UniAst | Error {
+  return blockNoteToUniAst.blocksToUniAst(editorRef.value!.document);
 }
 
 /**
@@ -212,7 +199,6 @@ const linkEditionCtx = createLinkEditionContext(container);
 const converterContext = createConverterContext(container);
 
 const blockNoteToUniAst = new BlockNoteToUniAstConverter(converterContext);
-const uniAstToMarkdown = new UniAstToMarkdownConverter(converterContext);
 
 const uniAstToBlockNote = new UniAstToBlockNoteConverter(converterContext);
 


### PR DESCRIPTION
# Jira URL

N/A

# Changes

## Description

* Make the BlockNote editor component syntax-agnostic instead of assuming Markdown

## Clarifications

* This should have been done since the beginning, so it's only fixing a problem we left temporarily

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A