### PR TITLE
CRISTAL-504: Migrate the groovy extension for XWiki into a contrib extension in Java

### DIFF
--- a/core/backends/backend-xwiki/src/xwikiStorage.ts
+++ b/core/backends/backend-xwiki/src/xwikiStorage.ts
@@ -80,11 +80,10 @@ export class XWikiStorage extends AbstractStorage {
 
   getPageRestURL(page: string, syntax: string, revision?: string): string {
     this.logger?.debug("XWiki Loading page", page);
-    const url = new URL(this.wikiConfig.baseURL + this.wikiConfig.baseRestURL);
-    const searchParams = new URLSearchParams([
-      ["page", page],
-      ["format", syntax],
-    ]);
+    const url = new URL(
+      this.buildPageRestBaseURL(page, ["rest", "cristal", "wikis", "xwiki"]),
+    );
+    const searchParams = new URLSearchParams([["format", syntax]]);
     if (revision) {
       searchParams.append("revision", revision);
     }
@@ -305,7 +304,7 @@ export class XWikiStorage extends AbstractStorage {
   }
 
   async save(page: string, title: string, content: string): Promise<unknown> {
-    const url = this.buildSavePageURL(page, ["rest", "wikis", "xwiki"]);
+    const url = this.buildPageRestBaseURL(page, ["rest", "wikis", "xwiki"]);
 
     const response = await fetch(url, {
       method: "PUT",
@@ -355,7 +354,7 @@ export class XWikiStorage extends AbstractStorage {
   }
 
   async delete(page: string): Promise<{ success: boolean; error?: string }> {
-    const url = this.buildSavePageURL(page, ["rest", "wikis", "xwiki"]);
+    const url = this.buildPageRestBaseURL(page, ["rest", "wikis", "xwiki"]);
 
     const success = await fetch(url, {
       method: "DELETE",
@@ -390,7 +389,7 @@ export class XWikiStorage extends AbstractStorage {
     return headers;
   }
 
-  private buildSavePageURL(page: string, segments: string[]) {
+  private buildPageRestBaseURL(page: string, segments: string[]) {
     const url = this.wikiConfig.baseURL;
     const referenceParts = page.split(".");
     for (let i = 0; i < referenceParts.length; i++) {

--- a/sources/xwiki/mock-server/src/index.ts
+++ b/sources/xwiki/mock-server/src/index.ts
@@ -55,71 +55,66 @@ ${revision ? "Revision " + revision : ""}
   return html;
 }
 
-app.get("/xwiki/rest/cristal/page", (req: Request, res: Response) => {
-  res.appendHeader("Access-Control-Allow-Origin", "*");
+app.get(
+  "/xwiki/rest/cristal/wikis/xwiki/spaces/*page",
+  (req: Request, res: Response) => {
+    res.appendHeader("Access-Control-Allow-Origin", "*");
 
-  const id: string = req.query.page as string;
-  let page: string = "";
-  let name: string = "";
-  let revision: string | undefined = undefined;
-  let text: string = "";
-  let html: string = "";
+    const id: string = (req.params.page as unknown as Array<string>)
+      .filter((_v: string, i: number) => i % 2 == 0)
+      .join(".");
 
-  switch (id) {
-    case "Main.WebHome":
-      page = "Main.WebHome";
-      name = "WebHome";
-      revision = (req.query.revision as string) || undefined;
-      text = `= Welcome to ${page} =
+    let page: string = "";
+    let name: string = "";
+    let revision: string | undefined = undefined;
+    let text: string = "";
+    let html: string = "";
+
+    switch (id) {
+      case "Main.WebHome":
+        page = "Main.WebHome";
+        name = "WebHome";
+        revision = (req.query.revision as string) || undefined;
+        text = `= Welcome to ${page} =
 
 XWiki is the best tool to organize your knowledge.
 
 [[XWiki Syntax>>Page2.WebHome]]
 ${revision ? "Revision " + revision : ""}
 }`;
-      html = getHtml(page, revision, { offline: false });
-      break;
+        html = getHtml(page, revision, { offline: false });
+        break;
 
-    case "Main.Offline":
-      page = "Main.Offline";
-      name = "Offline";
-      html = getHtml(page, revision, { offline: true });
-      break;
+      case "Main.Offline":
+        page = "Main.Offline";
+        name = "Offline";
+        html = getHtml(page, revision, { offline: true });
+        break;
 
-    case "Main.NewPage.WebHome":
-      res.sendStatus(404);
-      return;
+      case "Main.NewPage.WebHome":
+        res.sendStatus(404);
+        return;
 
-    default:
-      page = id;
-      name = "WebHome";
-      html = getHtml(page, revision, { offline: false });
-  }
+      default:
+        page = id;
+        name = "WebHome";
+        html = getHtml(page, revision, { offline: false });
+    }
 
-  res.json({
-    "@context": "https://schema.org",
-    "@type": "CreativeWork",
-    identifier: id,
-    name: name,
-    headline: page,
-    headlineRaw: page,
-    creator: page,
-    encodingFormat: "xwiki/2.1",
-    text: text,
-    html: html,
-  });
-});
-
-app.get("/xwiki/rest/cristal/panel", (req: Request, res: Response) => {
-  const panel = req.query.panel || "Main.WebHome";
-
-  res.appendHeader("Access-Control-Allow-Origin", "*");
-
-  res.json({
-    content: `<div>${panel}</div>`,
-    source: `= ${panel} =`,
-  });
-});
+    res.json({
+      "@context": "https://schema.org",
+      "@type": "CreativeWork",
+      identifier: id,
+      name: name,
+      headline: page,
+      headlineRaw: page,
+      creator: page,
+      encodingFormat: "xwiki/2.1",
+      text: text,
+      html: html,
+    });
+  },
+);
 
 app.get(
   "/xwiki/rest/wikis/xwiki/spaces/Main/pages/WebHome",


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->

https://jira.xwiki.org/browse/CRISTAL-504

# Changes

## Description

Small changes to use the endpoints provided by https://github.com/xwiki-contrib/cristal-integration.

**Warning:** do not merge until https://github.com/xwiki-contrib/cristal-integration/pull/1/ is merged.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

* N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A