### PR TITLE
CRISTAL-564: Document field of AttachmentReference is mandatory

### DIFF
--- a/core/model/model-api/src/index.ts
+++ b/core/model/model-api/src/index.ts
@@ -88,7 +88,7 @@ class DocumentReference implements BaseEntityReference {
 class AttachmentReference implements BaseEntityReference {
   type: EntityType.ATTACHMENT = EntityType.ATTACHMENT;
   name: string;
-  document: DocumentReference;
+  document?: DocumentReference;
 
   constructor(name: string, document: DocumentReference) {
     this.name = name;

--- a/core/model/model-remote-url/model-remote-url-filesystem/model-remote-url-filesystem-default/src/filesystemRemoteURLSerializer.ts
+++ b/core/model/model-remote-url/model-remote-url-filesystem/model-remote-url-filesystem-default/src/filesystemRemoteURLSerializer.ts
@@ -18,12 +18,7 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 
-import {
-  AttachmentReference,
-  DocumentReference,
-  EntityReference,
-  EntityType,
-} from "@xwiki/cristal-model-api";
+import { EntityReference, EntityType } from "@xwiki/cristal-model-api";
 import { RemoteURLSerializer } from "@xwiki/cristal-model-remote-url-api";
 import { protocol } from "@xwiki/cristal-model-remote-url-filesystem-api";
 import { injectable } from "inversify";
@@ -40,19 +35,19 @@ class FileSystemRemoteURLSerializer implements RemoteURLSerializer {
       case EntityType.SPACE:
         throw new Error("Not implemented");
       case EntityType.DOCUMENT: {
-        const documentReference = reference as DocumentReference;
+        const documentReference = reference;
         const spaces = documentReference.space?.names
           .map(encodeURIComponent)
           .join("/");
         return `${protocol}://${spaces}/${encodeURIComponent(documentReference.name)}`;
       }
       case EntityType.ATTACHMENT: {
-        const attachmentReference = reference as AttachmentReference;
+        const attachmentReference = reference;
         const documentReference = attachmentReference.document;
-        const spaces = documentReference.space?.names
+        const spaces = documentReference!.space?.names
           .map(encodeURIComponent)
           .join("/");
-        return `${protocol}://${spaces}/${encodeURIComponent(documentReference.name)}/attachments/${encodeURIComponent(attachmentReference.name)}`;
+        return `${protocol}://${spaces}/${encodeURIComponent(documentReference!.name)}/attachments/${encodeURIComponent(attachmentReference.name)}`;
       }
     }
   }

--- a/core/model/model-remote-url/model-remote-url-github/src/gitHubRemoteURLSerializer.ts
+++ b/core/model/model-remote-url/model-remote-url-github/src/gitHubRemoteURLSerializer.ts
@@ -61,8 +61,8 @@ class GitHubRemoteURLSerializer implements RemoteURLSerializer {
   private serializeAttachmentReference(
     attachmentReference: AttachmentReference,
   ) {
-    const spaces = attachmentReference.document.space?.names.join("/");
-    return `${this.getBaseURL()}/${spaces}/${attachmentReference.document.name}/${attachmentReference.name}`;
+    const spaces = attachmentReference.document?.space?.names.join("/");
+    return `${this.getBaseURL()}/${spaces}/${attachmentReference.document?.name}/${attachmentReference.name}`;
   }
 
   private getBaseURL() {

--- a/core/model/model-remote-url/model-remote-url-nextcloud/src/nextcloudRemoteURLSerializer.ts
+++ b/core/model/model-remote-url/model-remote-url-nextcloud/src/nextcloudRemoteURLSerializer.ts
@@ -59,7 +59,7 @@ class NextcloudRemoteURLSerializer implements RemoteURLSerializer {
   }
 
   private serializeAttachment(attachmentReference: AttachmentReference) {
-    return `${this.serializeDocument(attachmentReference.document)}/attachments/${attachmentReference.name}`;
+    return `${this.serializeDocument(attachmentReference.document!)}/attachments/${attachmentReference.name}`;
   }
 
   private getRootURL(username?: string) {

--- a/core/model/model-remote-url/model-remote-url-xwiki/src/xWikiRemoteURLSerializer.ts
+++ b/core/model/model-remote-url/model-remote-url-xwiki/src/xWikiRemoteURLSerializer.ts
@@ -54,8 +54,8 @@ class XWikiRemoteURLSerializer implements RemoteURLSerializer {
     const baseURL = this.cristalApp.getWikiConfig().baseURL;
     const attachmentReference = reference as AttachmentReference;
     const documentReference = attachmentReference.document;
-    const spaces = documentReference.space?.names.map(encodeURI).join("/");
-    return `${baseURL}/bin/download/${spaces}/${encodeURI(documentReference.name)}/${encodeURI(
+    const spaces = documentReference!.space?.names.map(encodeURI).join("/");
+    return `${baseURL}/bin/download/${spaces}/${encodeURI(documentReference!.name)}/${encodeURI(
       attachmentReference.name,
     )}`;
   }

--- a/core/tiptap-extensions/tiptap-extension-image/src/vue/ImageInsertView.vue
+++ b/core/tiptap-extensions/tiptap-extension-image/src/vue/ImageInsertView.vue
@@ -120,9 +120,9 @@ function convertLink(link: Link) {
     link.reference,
   ) as AttachmentReference;
   const documentReference = attachmentReference.document;
-  const segments = documentReference.space?.names.slice(0) ?? [];
+  const segments = documentReference?.space?.names.slice(0) ?? [];
   // TODO: replace with an actual construction of segments from a reference
-  if (documentReference.terminal) {
+  if (documentReference?.terminal) {
     segments.push(documentReference.name);
   }
   return {

--- a/editors/blocknote-headless/src/components/linkSuggest.ts
+++ b/editors/blocknote-headless/src/components/linkSuggest.ts
@@ -20,10 +20,7 @@
 
 import { EntityType } from "@xwiki/cristal-model-api";
 import type { Link, LinkSuggestService } from "@xwiki/cristal-link-suggest-api";
-import type {
-  AttachmentReference,
-  DocumentReference,
-} from "@xwiki/cristal-model-api";
+import type { DocumentReference } from "@xwiki/cristal-model-api";
 import type { ModelReferenceParser } from "@xwiki/cristal-model-reference-api";
 
 /**
@@ -96,13 +93,13 @@ function createLinkSuggestor(
 
         const documentReference =
           entityReference?.type == EntityType.ATTACHMENT
-            ? (entityReference as AttachmentReference).document
+            ? entityReference.document
             : (entityReference as DocumentReference);
 
-        const segments = documentReference.space?.names.slice(0) ?? [];
+        const segments = documentReference?.space?.names.slice(0) ?? [];
 
         // TODO: replace with an actual construction of segments from a reference
-        if (documentReference.terminal) {
+        if (documentReference?.terminal) {
           segments.push(documentReference.name);
         }
 

--- a/editors/blocknote-headless/src/vue/blocks/ImageEditor.vue
+++ b/editors/blocknote-headless/src/vue/blocks/ImageEditor.vue
@@ -138,10 +138,10 @@ function convertLink(link: Link): LinkSuggestion {
   ) as AttachmentReference;
 
   const documentReference = attachmentReference.document;
-  const segments = documentReference.space?.names.slice(0) ?? [];
+  const segments = documentReference?.space?.names.slice(0) ?? [];
 
   // TODO: replace with an actual construction of segments from a reference
-  if (documentReference.terminal) {
+  if (documentReference?.terminal) {
     segments.push(documentReference.name);
   }
 

--- a/editors/tiptap/src/components/extensions/link-suggest.ts
+++ b/editors/tiptap/src/components/extensions/link-suggest.ts
@@ -29,11 +29,7 @@ import Suggestion from "@tiptap/suggestion";
 import { Editor, Extension, Range } from "@tiptap/vue-3";
 import { SkinManager } from "@xwiki/cristal-api";
 import { Link } from "@xwiki/cristal-link-suggest-api";
-import {
-  AttachmentReference,
-  DocumentReference,
-  EntityType,
-} from "@xwiki/cristal-model-api";
+import { DocumentReference, EntityType } from "@xwiki/cristal-model-api";
 import { ModelReferenceParser } from "@xwiki/cristal-model-reference-api";
 import { Container } from "inversify";
 import { createPinia } from "pinia";
@@ -143,13 +139,13 @@ function initSuggestionsService(
 
         let documentReference;
         if (entityReference?.type == EntityType.ATTACHMENT) {
-          documentReference = (entityReference as AttachmentReference).document;
+          documentReference = entityReference.document;
         } else {
           documentReference = entityReference as DocumentReference;
         }
-        const segments = documentReference.space?.names.slice(0) ?? [];
+        const segments = documentReference?.space?.names.slice(0) ?? [];
         // TODO: replace with an actual construction of segments from a reference
-        if (documentReference.terminal) {
+        if (documentReference?.terminal) {
           segments.push(documentReference.name);
         }
         return {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-564

# Changes

## Description

The document field needs to be optional in order to support relative attachment references. This also makes it consistent with the other entity references.

## Clarifications

Note that in some places I updated the code to assert that the document field is not null, i.e. in some case we need the document field (e.g. when computing the attachment URL). We may need to define more clearly when the document field is needed and when it's not.

# Executed Tests

The unit tests that are executed by default with ``pnpm run build`.`

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A