### PR TITLE
CRISTAL-547: Upgrade to blocknote 0.31.2

### DIFF
--- a/editors/blocknote-headless/src/blocknote/uniast-to-bn.ts
+++ b/editors/blocknote-headless/src/blocknote/uniast-to-bn.ts
@@ -285,9 +285,7 @@ export class UniAstToBlockNoteConverter {
         url,
         caption: image.caption ?? "",
         showPreview: true,
-        // NOTE: 512 is the default width applied by BlockNote when inserting images in the editor
-        //       or when converting from Markdown / HTML
-        previewWidth: image.widthPx ?? 512,
+        previewWidth: image.widthPx ?? (undefined as unknown as number),
         backgroundColor: "default",
         textAlignment: image.styles.alignment ?? "left",
         name: image.alt ?? "",


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-547

# Changes

## Description

Remove leftover hack, since https://github.com/TypeCellOS/BlockNote/issues/1600 is now fixed.

# Executed Tests

``pnpm run build``

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A