### PR TITLE
CRISTAL-565: Strikethrough style is not properly converted from UnitAst to BlockNote syntax

### DIFF
--- a/editors/blocknote-headless/src/blocknote/uniast-to-bn.ts
+++ b/editors/blocknote-headless/src/blocknote/uniast-to-bn.ts
@@ -299,12 +299,31 @@ export class UniAstToBlockNoteConverter {
     inlineContent: InlineContent,
   ): EditorStyledText | EditorLink {
     switch (inlineContent.type) {
-      case "text":
+      case "text": {
+        const {
+          bold,
+          italic,
+          underline,
+          strikethrough,
+          code,
+          backgroundColor,
+          textColor,
+        } = inlineContent.styles;
+
         return {
           type: "text",
           text: inlineContent.content,
-          styles: inlineContent.styles,
+          styles: {
+            ...(bold && { bold }),
+            ...(italic && { italic }),
+            ...(underline && { underline }),
+            ...(strikethrough && { strike: true }),
+            ...(code && { code }),
+            ...(backgroundColor && { backgroundColor }),
+            ...(textColor && { textColor }),
+          },
         };
+      }
 
       case "link": {
         const href =


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-565

# Changes

## Description

Simply reverse the conversion done from BlockNote to UniAst.

# Executed Tests

``pnpm run build``

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A