### PR TITLE
CRISTAL-573: Upgrade to blocknote 0.33.0

### DIFF
--- a/core/fn-utils/src/index.ts
+++ b/core/fn-utils/src/index.ts
@@ -111,4 +111,27 @@ function tryFallibleOrError<T>(func: () => T): T | Error {
   }
 }
 
-export { assertInArray, assertUnreachable, tryFallible, tryFallibleOrError };
+/**
+ * Provide a type for expressions type inference
+ *
+ * This is actually an identity function - the provided value is returned as is, with no other operation.
+ *
+ * @since 0.20
+ *
+ * @param value - The value to return
+ * @returns - The provided value
+ *
+ * @example `[1].concat("Hello")` // Type error
+ * @example `provideTypeInference<number | string>([1].concat("Hello"))` // Works
+ */
+function provideTypeInference<T>(value: T): T {
+  return value;
+}
+
+export {
+  assertInArray,
+  assertUnreachable,
+  provideTypeInference,
+  tryFallible,
+  tryFallibleOrError,
+};

--- a/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
+++ b/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
@@ -65,8 +65,7 @@ export class BlockNoteToUniAstConverter {
       if (
         block.type !== "bulletListItem" &&
         block.type !== "numberedListItem" &&
-        block.type !== "checkListItem" &&
-        block.type !== "toggleListItem"
+        block.type !== "checkListItem"
       ) {
         const converted = this.convertBlock(block);
 
@@ -101,11 +100,7 @@ export class BlockNoteToUniAstConverter {
       BlockType,
       {
         // List items are to be handled through the `convertListItem` method
-        type:
-          | "bulletListItem"
-          | "numberedListItem"
-          | "checkListItem"
-          | "toggleListItem";
+        type: "bulletListItem" | "numberedListItem" | "checkListItem";
       }
     >,
   ): Block | null {
@@ -254,19 +249,12 @@ export class BlockNoteToUniAstConverter {
     block: Extract<
       BlockType,
       {
-        type:
-          | "bulletListItem"
-          | "numberedListItem"
-          | "checkListItem"
-          | "toggleListItem";
+        type: "bulletListItem" | "numberedListItem" | "checkListItem";
       }
     >,
     currentList: Extract<Block, { type: "list" }> | null,
   ): ListItem {
     switch (block.type) {
-      // TODO: togglable list items are not supported by Markdown, so we convert it as raw here
-      // Should we convert them differently?
-      case "toggleListItem":
       case "bulletListItem":
         return {
           content: [

--- a/editors/blocknote-react/src/blocknote/index.ts
+++ b/editors/blocknote-react/src/blocknote/index.ts
@@ -53,7 +53,8 @@ import {
 function createBlockNoteSchema() {
   // Get rid of some block types
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  const { audio, video, file, ...remainingBlockSpecs } = defaultBlockSpecs;
+  const { audio, video, file, toggleListItem, ...remainingBlockSpecs } =
+    defaultBlockSpecs;
 
   const blockNoteSchema = BlockNoteSchema.create({
     blockSpecs: {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-573

# Changes

## Description

* Remove support for togglable list items in BlockNote
* Fix togglable headings' content preventing save

## Clarifications

* We don't have support for togglable list items currently, so just like files and audio items, we remove them from the schema for now
* Headings previously couldn't have children elements, so saving doesn't work anymore - this PR fixes that and saves the child as being normal elements below their parent heading

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A