### PR TITLE
CRISTAL-44:  Macros can be viewed using client side rendering

### DIFF
--- a/core/fn-utils/src/index.ts
+++ b/core/fn-utils/src/index.ts
@@ -128,9 +128,31 @@ function provideTypeInference<T>(value: T): T {
   return value;
 }
 
+/**
+ * Filter and map an array's values
+ *
+ * Combines both `.filter` and `.map` with the additional benefit of conditional type predicates
+ *
+ * @since 0.20
+ *
+ * @param array - The array to map
+ * @param filterMap - The function performing the mapping and filtering. Returning `null` or `undefined` corresponds to filter values out.
+ *
+ * @returns The filtered and mapped array
+ */
+function filterMap<T, U>(
+  array: T[],
+  filterMap: (value: T, index: number) => U | null | undefined,
+): U[] {
+  return array
+    .map(filterMap)
+    .filter((value) => value !== null && value !== undefined);
+}
+
 export {
   assertInArray,
   assertUnreachable,
+  filterMap,
   provideTypeInference,
   tryFallible,
   tryFallibleOrError,

--- a/core/fn-utils/src/index.ts
+++ b/core/fn-utils/src/index.ts
@@ -135,6 +135,8 @@ function provideTypeInference<T>(value: T): T {
  *
  * @since 0.20
  *
+ * @example `filterMap([1, 2, 3], value => value >= 2 ? value.toString() : null) // ['2', '3']`
+ *
  * @param array - The array to map
  * @param filterMap - The function performing the mapping and filtering. Returning `null` or `undefined` corresponds to filter values out.
  *

--- a/core/uniast/src/__tests__/converters.test.ts
+++ b/core/uniast/src/__tests__/converters.test.ts
@@ -1008,7 +1008,9 @@ describe("MarkdownToUniAstConverter", () => {
         ],
       },
     });
+  });
 
+  test("parse various macros syntaxes", () => {
     testTwoWayConversion({
       startingFrom: [
         "{{macro/}}",
@@ -1021,7 +1023,7 @@ describe("MarkdownToUniAstConverter", () => {
         '{{macro param1="1" /}}',
         '{{macro param1="1" param2="2" /}}',
         '{{macro param1="param1Value" param2="param2Value" param3="param3Value" /}}',
-        '{{macro param1="some \\" escaped quote and }} closing braces and \\\\ escaped backslashes" /}}',
+        '{{macro param1="some \\\\" escaped quote and }} closing braces and \\\\\\ escaped backslashes" /}}',
       ].join("\n"),
       convertsBackTo: [
         "{{macro /}}",
@@ -1034,10 +1036,140 @@ describe("MarkdownToUniAstConverter", () => {
         '{{macro param1="1" /}}',
         '{{macro param1="1" param2="2" /}}',
         '{{macro param1="param1Value" param2="param2Value" param3="param3Value" /}}',
-        '{{macro param1="some \\" escaped quote and }} closing braces and \\\\ escaped backslashes" /}}',
+        '{{macro param1="some \\\\" escaped quote and }} closing braces and \\\\\\ escaped backslashes" /}}',
       ].join("\n"),
       withUniAst: {
-        blocks: [],
+        blocks: [
+          {
+            content: [
+              {
+                name: "macro",
+                props: {},
+                type: "inlineMacro",
+              },
+              {
+                content: "\n",
+                styles: {},
+                type: "text",
+              },
+              {
+                name: "macro",
+                props: {},
+                type: "inlineMacro",
+              },
+              {
+                content: "\n",
+                styles: {},
+                type: "text",
+              },
+              {
+                name: "macro",
+                props: {},
+                type: "inlineMacro",
+              },
+              {
+                content: "\n",
+                styles: {},
+                type: "text",
+              },
+              {
+                name: "macro",
+                props: {},
+                type: "inlineMacro",
+              },
+              {
+                content: "\n",
+                styles: {},
+                type: "text",
+              },
+              {
+                name: "macro",
+                props: {
+                  param1: "1",
+                },
+                type: "inlineMacro",
+              },
+              {
+                content: "\n",
+                styles: {},
+                type: "text",
+              },
+              {
+                name: "macro",
+                props: {
+                  param1: "1",
+                },
+                type: "inlineMacro",
+              },
+              {
+                content: "\n",
+                styles: {},
+                type: "text",
+              },
+              {
+                name: "macro",
+                props: {
+                  param1: "1",
+                },
+                type: "inlineMacro",
+              },
+              {
+                content: "\n",
+                styles: {},
+                type: "text",
+              },
+              {
+                name: "macro",
+                props: {
+                  param1: "1",
+                },
+                type: "inlineMacro",
+              },
+              {
+                content: "\n",
+                styles: {},
+                type: "text",
+              },
+              {
+                name: "macro",
+                props: {
+                  param1: "1",
+                  param2: "2",
+                },
+                type: "inlineMacro",
+              },
+              {
+                content: "\n",
+                styles: {},
+                type: "text",
+              },
+              {
+                name: "macro",
+                props: {
+                  param1: "param1Value",
+                  param2: "param2Value",
+                  param3: "param3Value",
+                },
+                type: "inlineMacro",
+              },
+              {
+                content: "\n",
+                styles: {},
+                type: "text",
+              },
+              {
+                name: "macro",
+                props: {
+                  param1:
+                    'some " escaped quote and }} closing braces and \\ escaped backslashes',
+                },
+                type: "inlineMacro",
+              },
+            ],
+            styles: {},
+            type: "paragraph",
+          },
+        ],
       },
     });
   });

--- a/core/uniast/src/__tests__/converters.test.ts
+++ b/core/uniast/src/__tests__/converters.test.ts
@@ -993,7 +993,7 @@ describe("MarkdownToUniAstConverter", () => {
               },
               {
                 name: "macro",
-                props: {},
+                params: {},
                 type: "inlineMacro",
               },
               {
@@ -1024,7 +1024,7 @@ describe("MarkdownToUniAstConverter", () => {
         '{{macro param1="1" param2="2" /}}',
         '{{macro param1="param1Value" param2="param2Value" param3="param3Value" /}}',
         '{{macro param1="some \\\\" escaped quote and }} closing braces and \\\\\\ escaped backslashes" /}}',
-      ].join("\n"),
+      ].join("\n\n"),
       convertsBackTo: [
         "{{macro /}}",
         "{{macro /}}",
@@ -1037,142 +1037,86 @@ describe("MarkdownToUniAstConverter", () => {
         '{{macro param1="1" param2="2" /}}',
         '{{macro param1="param1Value" param2="param2Value" param3="param3Value" /}}',
         '{{macro param1="some \\\\" escaped quote and }} closing braces and \\\\\\ escaped backslashes" /}}',
-      ].join("\n"),
+      ].join("\n\n"),
       withUniAst: {
         blocks: [
           {
-            content: [
-              {
-                name: "macro",
-                props: {},
-                type: "inlineMacro",
-              },
-              {
-                content: "\n",
-                styles: {},
-                type: "text",
-              },
-              {
-                name: "macro",
-                props: {},
-                type: "inlineMacro",
-              },
-              {
-                content: "\n",
-                styles: {},
-                type: "text",
-              },
-              {
-                name: "macro",
-                props: {},
-                type: "inlineMacro",
-              },
-              {
-                content: "\n",
-                styles: {},
-                type: "text",
-              },
-              {
-                name: "macro",
-                props: {},
-                type: "inlineMacro",
-              },
-              {
-                content: "\n",
-                styles: {},
-                type: "text",
-              },
-              {
-                name: "macro",
-                props: {
-                  param1: "1",
-                },
-                type: "inlineMacro",
-              },
-              {
-                content: "\n",
-                styles: {},
-                type: "text",
-              },
-              {
-                name: "macro",
-                props: {
-                  param1: "1",
-                },
-                type: "inlineMacro",
-              },
-              {
-                content: "\n",
-                styles: {},
-                type: "text",
-              },
-              {
-                name: "macro",
-                props: {
-                  param1: "1",
-                },
-                type: "inlineMacro",
-              },
-              {
-                content: "\n",
-                styles: {},
-                type: "text",
-              },
-              {
-                name: "macro",
-                props: {
-                  param1: "1",
-                },
-                type: "inlineMacro",
-              },
-              {
-                content: "\n",
-                styles: {},
-                type: "text",
-              },
-              {
-                name: "macro",
-                props: {
-                  param1: "1",
-                  param2: "2",
-                },
-                type: "inlineMacro",
-              },
-              {
-                content: "\n",
-                styles: {},
-                type: "text",
-              },
-              {
-                name: "macro",
-                props: {
-                  param1: "param1Value",
-                  param2: "param2Value",
-                  param3: "param3Value",
-                },
-                type: "inlineMacro",
-              },
-              {
-                content: "\n",
-                styles: {},
-                type: "text",
-              },
-              {
-                name: "macro",
-                props: {
-                  param1:
-                    'some " escaped quote and }} closing braces and \\ escaped backslashes',
-                },
-                type: "inlineMacro",
-              },
-            ],
-            styles: {},
-            type: "paragraph",
+            name: "macro",
+            params: {},
+            type: "macroBlock",
+          },
+          {
+            name: "macro",
+            params: {},
+            type: "macroBlock",
+          },
+          {
+            name: "macro",
+            params: {},
+            type: "macroBlock",
+          },
+          {
+            name: "macro",
+            params: {},
+            type: "macroBlock",
+          },
+          {
+            name: "macro",
+            params: {
+              param1: "1",
+            },
+            type: "macroBlock",
+          },
+          {
+            name: "macro",
+            params: {
+              param1: "1",
+            },
+            type: "macroBlock",
+          },
+          {
+            name: "macro",
+            params: {
+              param1: "1",
+            },
+            type: "macroBlock",
+          },
+          {
+            name: "macro",
+            params: {
+              param1: "1",
+            },
+            type: "macroBlock",
+          },
+          {
+            name: "macro",
+            params: {
+              param1: "1",
+              param2: "2",
+            },
+            type: "macroBlock",
+          },
+          {
+            name: "macro",
+            params: {
+              param1: "param1Value",
+              param2: "param2Value",
+              param3: "param3Value",
+            },
+            type: "macroBlock",
+          },
+          {
+            name: "macro",
+            params: {
+              param1:
+                'some " escaped quote and }} closing braces and \\ escaped backslashes',
+            },
+            type: "macroBlock",
           },
         ],
       },
     });
-  });
 
-  // TODO: test a lot of macro syntaxes
+    // TODO: inline macros test
+  });
 });

--- a/core/uniast/src/__tests__/converters.test.ts
+++ b/core/uniast/src/__tests__/converters.test.ts
@@ -938,12 +938,12 @@ describe("MarkdownToUniAstConverter", () => {
       startingFrom: [
         "A [[title|documentReference]] B",
         "C ![[title|imageReference]] D",
-        "E {{macro /}} F",
+        "E {{inlineMacro /}} F",
       ].join("\n"),
       convertsBackTo: [
         "A [[title|documentReference]] B",
         "C ![[title|imageReference]] D",
-        "E {{macro /}} F",
+        "E {{inlineMacro /}} F",
       ].join("\n"),
       withUniAst: {
         blocks: [
@@ -1116,7 +1116,5 @@ describe("MarkdownToUniAstConverter", () => {
         ],
       },
     });
-
-    // TODO: inline macros test
   });
 });

--- a/core/uniast/src/__tests__/converters.test.ts
+++ b/core/uniast/src/__tests__/converters.test.ts
@@ -938,12 +938,12 @@ describe("MarkdownToUniAstConverter", () => {
       startingFrom: [
         "A [[title|documentReference]] B",
         "C ![[title|imageReference]] D",
-        "E {{inlineMacro /}} F",
+        "E {{someInlineMacro /}} F",
       ].join("\n"),
       convertsBackTo: [
         "A [[title|documentReference]] B",
         "C ![[title|imageReference]] D",
-        "E {{inlineMacro /}} F",
+        "E {{someInlineMacro /}} F",
       ].join("\n"),
       withUniAst: {
         blocks: [
@@ -992,7 +992,7 @@ describe("MarkdownToUniAstConverter", () => {
                 type: "text",
               },
               {
-                name: "macro",
+                name: "someInlineMacro",
                 params: {},
                 type: "inlineMacro",
               },

--- a/core/uniast/src/ast.ts
+++ b/core/uniast/src/ast.ts
@@ -57,7 +57,7 @@ type Block =
       /** @since 0.20 */
       type: "macroBlock";
       name: string;
-      props: Record<string, boolean | number | string>;
+      params: Record<string, number | string>;
     };
 
 /**
@@ -126,7 +126,7 @@ type InlineContent =
       /** @since 0.20 */
       type: "inlineMacro";
       name: string;
-      props: Record<string, boolean | number | string>;
+      params: Record<string, number | string>;
     };
 
 /**

--- a/core/uniast/src/ast.ts
+++ b/core/uniast/src/ast.ts
@@ -54,9 +54,11 @@ type Block =
     } & Image)
   | { type: "break" }
   | {
-      type: "macro";
+      /** @since 0.20 */
+      type: "macroBlock";
       name: string;
       props: Record<string, boolean | number | string>;
+      content?: Block[];
     };
 
 /**
@@ -120,6 +122,13 @@ type InlineContent =
       type: "link";
       target: LinkTarget;
       content: Exclude<InlineContent, { type: "link" }>[];
+    }
+  | {
+      /** @since 0.20 */
+      type: "inlineMacro";
+      name: string;
+      props: Record<string, boolean | number | string>;
+      content?: InlineContent[];
     };
 
 /**

--- a/core/uniast/src/ast.ts
+++ b/core/uniast/src/ast.ts
@@ -57,7 +57,7 @@ type Block =
       /** @since 0.20 */
       type: "macroBlock";
       name: string;
-      params: Record<string, number | string>;
+      params: Record<string, boolean | number | string>;
     };
 
 /**
@@ -126,7 +126,7 @@ type InlineContent =
       /** @since 0.20 */
       type: "inlineMacro";
       name: string;
-      params: Record<string, number | string>;
+      params: Record<string, boolean | number | string>;
     };
 
 /**

--- a/core/uniast/src/ast.ts
+++ b/core/uniast/src/ast.ts
@@ -154,7 +154,19 @@ type TextStyles = {
  * @since 0.16
  */
 type LinkTarget =
-  | { type: "internal"; reference: EntityReference }
+  | {
+      type: "internal";
+
+      /** @since 0.20 */
+      rawReference: string;
+
+      /**
+       * Will be `null` if the raw reference is invalid and can't be parsed
+       *
+       * @since 0.20
+       */
+      parsedReference: EntityReference | null;
+    }
   | { type: "external"; url: string };
 
 export type {

--- a/core/uniast/src/ast.ts
+++ b/core/uniast/src/ast.ts
@@ -58,7 +58,6 @@ type Block =
       type: "macroBlock";
       name: string;
       props: Record<string, boolean | number | string>;
-      content?: Block[];
     };
 
 /**
@@ -128,7 +127,6 @@ type InlineContent =
       type: "inlineMacro";
       name: string;
       props: Record<string, boolean | number | string>;
-      content?: InlineContent[];
     };
 
 /**

--- a/core/uniast/src/markdown/md-to-uniast.ts
+++ b/core/uniast/src/markdown/md-to-uniast.ts
@@ -81,14 +81,26 @@ export class MarkdownToUniAstConverter {
 
   private convertBlock(block: RootContent): Block {
     switch (block.type) {
-      case "paragraph":
+      case "paragraph": {
+        const content = block.children.flatMap((item) =>
+          this.convertInline(item, {}),
+        );
+
+        // Paragraphs only made of a single inline macro are actually block macros
+        if (content.length === 1 && content[0].type === "inlineMacro") {
+          return {
+            type: "macroBlock",
+            name: content[0].name,
+            params: content[0].params,
+          };
+        }
+
         return {
           type: "paragraph",
-          content: block.children.flatMap((item) =>
-            this.convertInline(item, {}),
-          ),
+          content,
           styles: {},
         };
+      }
 
       case "heading":
         return {
@@ -559,7 +571,7 @@ export class MarkdownToUniAstConverter {
             out.push({
               type: "inlineMacro",
               name: macroName,
-              props: parameters,
+              params: parameters,
             });
           }
 

--- a/core/uniast/src/markdown/md-to-uniast.ts
+++ b/core/uniast/src/markdown/md-to-uniast.ts
@@ -567,7 +567,9 @@ export class MarkdownToUniAstConverter {
           // Otherwise, we can properly build the macro
           else {
             treated = i + 1 + closingBraces[0].length;
-            // TODO: macro blocks
+
+            // NOTE: If a paragraph only contains an inline macro, it will be converted to a macro block instead
+            //       by the calling function
             out.push({
               type: "inlineMacro",
               name: macroName,

--- a/core/uniast/src/markdown/uniast-to-md.ts
+++ b/core/uniast/src/markdown/uniast-to-md.ts
@@ -87,8 +87,10 @@ export class UniAstToMarkdownConverter {
       case "break":
         return "---";
 
-      case "macro":
-        throw new Error("TODO: handle macros");
+      case "macroBlock":
+        // TODO: keep ordering of properties
+        // TODO: escape double quotes in values
+        return `{{${block.name}${Object.entries(block.props).map(([name, value]) => ` ${name}="${value}"`)} /}}`;
     }
   }
 
@@ -159,6 +161,13 @@ export class UniAstToMarkdownConverter {
           case "internal":
             return `[[${this.convertInlineContents(inlineContent.content)}|${this.context.serializeReference(inlineContent.target.reference)}]]`;
         }
+
+        break;
+
+      case "inlineMacro":
+        // TODO: keep ordering of properties
+        // TODO: escape double quotes in values
+        return `{{${inlineContent.name}${Object.entries(inlineContent.props).map(([name, value]) => ` ${name}="${value}"`)} /}}`;
     }
   }
 

--- a/core/uniast/src/markdown/uniast-to-md.ts
+++ b/core/uniast/src/markdown/uniast-to-md.ts
@@ -27,7 +27,6 @@ import {
   Text,
   UniAst,
 } from "../ast";
-import { ConverterContext } from "../interface";
 import { tryFallibleOrError } from "@xwiki/cristal-fn-utils";
 
 /**
@@ -36,7 +35,7 @@ import { tryFallibleOrError } from "@xwiki/cristal-fn-utils";
  * @since 0.16
  */
 export class UniAstToMarkdownConverter {
-  constructor(public context: ConverterContext) {}
+  constructor() {}
 
   toMarkdown(uniAst: UniAst): string | Error {
     const { blocks } = uniAst;
@@ -113,7 +112,7 @@ export class UniAstToMarkdownConverter {
     // TODO: alt text
     return image.target.type === "external"
       ? `![${image.alt}](${image.target.url})`
-      : `![[${image.alt}|${this.context.serializeReference(image.target.reference)}]]`;
+      : `![[${image.alt}|${image.target.rawReference}]]`;
   }
 
   private convertTable(table: Extract<Block, { type: "table" }>): string {
@@ -159,7 +158,7 @@ export class UniAstToMarkdownConverter {
             return `[${this.convertInlineContents(inlineContent.content)}](${inlineContent.target.url})`;
 
           case "internal":
-            return `[[${this.convertInlineContents(inlineContent.content)}|${this.context.serializeReference(inlineContent.target.reference)}]]`;
+            return `[[${this.convertInlineContents(inlineContent.content)}|${inlineContent.target.rawReference}]]`;
         }
 
         break;

--- a/core/uniast/src/markdown/uniast-to-md.ts
+++ b/core/uniast/src/markdown/uniast-to-md.ts
@@ -167,7 +167,9 @@ export class UniAstToMarkdownConverter {
       case "inlineMacro":
         // TODO: keep ordering of properties
         // TODO: escape double quotes in values
-        return `{{${inlineContent.name}${Object.entries(inlineContent.props).map(([name, value]) => ` ${name}="${value}"`)} /}}`;
+        return `{{${inlineContent.name}${Object.entries(inlineContent.props)
+          .map(([name, value]) => ` ${name}="${value}"`)
+          .join(" ")} /}}`;
     }
   }
 

--- a/core/uniast/src/markdown/uniast-to-md.ts
+++ b/core/uniast/src/markdown/uniast-to-md.ts
@@ -35,8 +35,6 @@ import { tryFallibleOrError } from "@xwiki/cristal-fn-utils";
  * @since 0.16
  */
 export class UniAstToMarkdownConverter {
-  constructor() {}
-
   toMarkdown(uniAst: UniAst): string | Error {
     const { blocks } = uniAst;
 

--- a/core/uniast/src/markdown/uniast-to-md.ts
+++ b/core/uniast/src/markdown/uniast-to-md.ts
@@ -167,8 +167,11 @@ export class UniAstToMarkdownConverter {
         // TODO: keep ordering of properties
         // TODO: escape double quotes in values
         return `{{${inlineContent.name}${Object.entries(inlineContent.props)
-          .map(([name, value]) => ` ${name}="${value}"`)
-          .join(" ")} /}}`;
+          .map(
+            ([name, value]) =>
+              ` ${name}="${value.toString().replace(/\\/g, "\\\\\\").replace(/"/g, '\\\\"')}"`,
+          )
+          .join("")} /}}`;
     }
   }
 

--- a/core/uniast/src/markdown/uniast-to-md.ts
+++ b/core/uniast/src/markdown/uniast-to-md.ts
@@ -168,7 +168,7 @@ export class UniAstToMarkdownConverter {
 
   private convertMacro(
     name: string,
-    parameters: Record<string, number | string>,
+    parameters: Record<string, boolean | number | string>,
   ): string {
     return `{{${name}${Object.entries(parameters)
       .map(

--- a/core/uniast/src/markdown/uniast-to-md.ts
+++ b/core/uniast/src/markdown/uniast-to-md.ts
@@ -87,9 +87,7 @@ export class UniAstToMarkdownConverter {
         return "---";
 
       case "macroBlock":
-        // TODO: keep ordering of properties
-        // TODO: escape double quotes in values
-        return `{{${block.name}${Object.entries(block.props).map(([name, value]) => ` ${name}="${value}"`)} /}}`;
+        return this.convertMacro(block.name, block.params);
     }
   }
 
@@ -164,15 +162,20 @@ export class UniAstToMarkdownConverter {
         break;
 
       case "inlineMacro":
-        // TODO: keep ordering of properties
-        // TODO: escape double quotes in values
-        return `{{${inlineContent.name}${Object.entries(inlineContent.props)
-          .map(
-            ([name, value]) =>
-              ` ${name}="${value.toString().replace(/\\/g, "\\\\\\").replace(/"/g, '\\\\"')}"`,
-          )
-          .join("")} /}}`;
+        return this.convertMacro(inlineContent.name, inlineContent.params);
     }
+  }
+
+  private convertMacro(
+    name: string,
+    parameters: Record<string, number | string>,
+  ): string {
+    return `{{${name}${Object.entries(parameters)
+      .map(
+        ([name, value]) =>
+          ` ${name}="${value.toString().replace(/\\/g, "\\\\\\").replace(/"/g, '\\\\"')}"`,
+      )
+      .join("")} /}}`;
   }
 
   // eslint-disable-next-line max-statements

--- a/editors/blocknote-headless/src/index.ts
+++ b/editors/blocknote-headless/src/index.ts
@@ -2,5 +2,5 @@ import BlocknoteEditor from "./vue/c-blocknote-view.vue";
 import type { EditorType } from "@xwiki/cristal-editors-blocknote-react";
 
 export { BlocknoteEditor };
-
 export type { EditorType };
+export { DEFAULT_MACROS } from "@xwiki/cristal-editors-blocknote-react";

--- a/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
+++ b/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
@@ -419,7 +419,12 @@ export class BlockNoteToUniAstConverter {
     const reference = this.context.parseReferenceFromUrl(url);
 
     return reference
-      ? { type: "internal", reference }
+      ? {
+          type: "internal",
+          parsedReference: reference,
+          // TODO: preserve the raw reference from the original UniAst
+          rawReference: this.context.serializeReference(reference),
+        }
       : { type: "external", url };
   }
 }

--- a/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
+++ b/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
@@ -25,6 +25,7 @@ import {
   EditorLink,
   EditorStyleSchema,
   EditorStyledText,
+  MACRO_NAME_PREFIX,
 } from "@xwiki/cristal-editors-blocknote-react";
 import {
   assertUnreachable,
@@ -114,6 +115,15 @@ export class BlockNoteToUniAstConverter {
         throw new Error("Unexpected children in block type: " + block.type);
       }
     };
+
+    // Convert macros
+    if (block.type.startsWith(MACRO_NAME_PREFIX)) {
+      return {
+        type: "macroBlock",
+        name: block.type.substring(MACRO_NAME_PREFIX.length),
+        props: block.props,
+      };
+    }
 
     switch (block.type) {
       case "paragraph":
@@ -348,6 +358,17 @@ export class BlockNoteToUniAstConverter {
   private convertInlineContent(
     inlineContent: EditorStyledText | Link<EditorStyleSchema>,
   ): InlineContent {
+    // Handle macros
+    if (inlineContent.type.startsWith(MACRO_NAME_PREFIX)) {
+      return {
+        type: "inlineMacro",
+        name: inlineContent.type.substring(MACRO_NAME_PREFIX.length),
+        props:
+          // @ts-expect-error: TODO
+          inlineContent.props,
+      };
+    }
+
     switch (inlineContent.type) {
       case "text": {
         const {

--- a/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
+++ b/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
@@ -364,7 +364,7 @@ export class BlockNoteToUniAstConverter {
         type: "inlineMacro",
         name: inlineContent.type.substring(MACRO_NAME_PREFIX.length),
         props:
-          // @ts-expect-error: TODO
+          // @ts-expect-error: the AST is dynamically-typed with macros, so the types are incorrect here
           inlineContent.props,
       };
     }
@@ -423,6 +423,10 @@ export class BlockNoteToUniAstConverter {
           type: "internal",
           parsedReference: reference,
           // TODO: preserve the raw reference from the original UniAst
+          //
+          // Waiting for solved issue in BlockNote:
+          // > https://github.com/TypeCellOS/BlockNote/issues/1840
+          //
           rawReference: this.context.serializeReference(reference),
         }
       : { type: "external", url };

--- a/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
+++ b/editors/blocknote-headless/src/uniast/bn-to-uniast.ts
@@ -121,7 +121,7 @@ export class BlockNoteToUniAstConverter {
       return {
         type: "macroBlock",
         name: block.type.substring(MACRO_NAME_PREFIX.length),
-        props: block.props,
+        params: block.props,
       };
     }
 
@@ -363,7 +363,7 @@ export class BlockNoteToUniAstConverter {
       return {
         type: "inlineMacro",
         name: inlineContent.type.substring(MACRO_NAME_PREFIX.length),
-        props:
+        params:
           // @ts-expect-error: the AST is dynamically-typed with macros, so the types are incorrect here
           inlineContent.props,
       };

--- a/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
+++ b/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
@@ -190,10 +190,8 @@ export class UniAstToBlockNoteConverter {
           // @ts-expect-error: macros are dynamically added to the AST
           type: `${MACRO_NAME_PREFIX}${block.name}`,
           id: genId(),
+          // @ts-expect-error: macros are dynamically added to the AST so the properties are not typed properly
           props: block.props,
-          children:
-            block.content?.flatMap((item) => this.convertBlock(item)) ?? [],
-          content: undefined,
         };
 
       default:
@@ -368,8 +366,9 @@ export class UniAstToBlockNoteConverter {
 
       case "inlineMacro":
         return {
-          // f@ts-expect-error: macros are dynamically added to the AST
-          type: "yoh",
+          // @ts-expect-error: macros are dynamically added to the AST
+          type: `${MACRO_NAME_PREFIX}${inlineContent.name}`,
+          props: inlineContent.props,
         };
     }
   }

--- a/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
+++ b/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
@@ -289,7 +289,7 @@ export class UniAstToBlockNoteConverter {
         ? image.target.url
         : image.target.parsedReference
           ? this.context.getUrlFromReference(image.target.parsedReference)
-          : // TODO: error handling, attach metadata to indicate the reference is invalid, ...?
+          : // TODO: think about what to do in case of invalid reference - let it as it is, show an error, replace by a fallback, ...?
             "about:blank";
 
     return {
@@ -349,7 +349,7 @@ export class UniAstToBlockNoteConverter {
               ? this.context.getUrlFromReference(
                   inlineContent.target.parsedReference,
                 )
-              : // TODO: error handling, attach metadata to indicate the reference is invalid, ...?
+              : // TODO: think about what to do in case of invalid reference - let it as it is, show an error, replace by a fallback, ...?
                 "about:blank";
 
         return {

--- a/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
+++ b/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
@@ -290,7 +290,7 @@ export class UniAstToBlockNoteConverter {
         : image.target.parsedReference
           ? this.context.getUrlFromReference(image.target.parsedReference)
           : // TODO: think about what to do in case of invalid reference - let it as it is, show an error, replace by a fallback, ...?
-            "about:blank";
+            image.target.rawReference;
 
     return {
       type: "image",
@@ -350,7 +350,7 @@ export class UniAstToBlockNoteConverter {
                   inlineContent.target.parsedReference,
                 )
               : // TODO: think about what to do in case of invalid reference - let it as it is, show an error, replace by a fallback, ...?
-                "about:blank";
+                inlineContent.target.rawReference;
 
         return {
           type: "link",

--- a/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
+++ b/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
@@ -287,7 +287,10 @@ export class UniAstToBlockNoteConverter {
     const url =
       image.target.type === "external"
         ? image.target.url
-        : this.context.getUrlFromReference(image.target.reference);
+        : image.target.parsedReference
+          ? this.context.getUrlFromReference(image.target.parsedReference)
+          : // TODO: error handling, attach metadata to indicate the reference is invalid, ...?
+            "about:blank";
 
     return {
       type: "image",
@@ -342,7 +345,12 @@ export class UniAstToBlockNoteConverter {
         const href =
           inlineContent.target.type === "external"
             ? inlineContent.target.url
-            : this.context.getUrlFromReference(inlineContent.target.reference);
+            : inlineContent.target.parsedReference
+              ? this.context.getUrlFromReference(
+                  inlineContent.target.parsedReference,
+                )
+              : // TODO: error handling, attach metadata to indicate the reference is invalid, ...?
+                "about:blank";
 
         return {
           type: "link",

--- a/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
+++ b/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
@@ -376,7 +376,7 @@ export class UniAstToBlockNoteConverter {
         return {
           // @ts-expect-error: macros are dynamically added to the AST
           type: `${MACRO_NAME_PREFIX}${inlineContent.name}`,
-          props: inlineContent.props,
+          props: inlineContent.params,
         };
     }
   }

--- a/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
+++ b/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
@@ -25,8 +25,9 @@ import {
   EditorLink,
   EditorStyleSchema,
   EditorStyledText,
+  MACRO_NAME_PREFIX,
 } from "@xwiki/cristal-editors-blocknote-react";
-import { tryFallibleOrError } from "@xwiki/cristal-fn-utils";
+import { assertUnreachable, tryFallibleOrError } from "@xwiki/cristal-fn-utils";
 import {
   Block,
   BlockStyles,
@@ -182,8 +183,21 @@ export class UniAstToBlockNoteConverter {
         return this.convertImage(block);
 
       case "break":
-      case "macro":
         throw new Error("TODO: handle block of type " + block.type);
+
+      case "macroBlock":
+        return {
+          // @ts-expect-error: macros are dynamically added to the AST
+          type: `${MACRO_NAME_PREFIX}${block.name}`,
+          id: genId(),
+          props: block.props,
+          children:
+            block.content?.flatMap((item) => this.convertBlock(item)) ?? [],
+          content: undefined,
+        };
+
+      default:
+        assertUnreachable(block);
     }
   }
 
@@ -351,6 +365,12 @@ export class UniAstToBlockNoteConverter {
 
       case "image":
         throw new Error("Inline images are currently unsupported in blocknote");
+
+      case "inlineMacro":
+        return {
+          // f@ts-expect-error: macros are dynamically added to the AST
+          type: "yoh",
+        };
     }
   }
 }

--- a/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
+++ b/editors/blocknote-headless/src/uniast/uniast-to-bn.ts
@@ -191,7 +191,7 @@ export class UniAstToBlockNoteConverter {
           type: `${MACRO_NAME_PREFIX}${block.name}`,
           id: genId(),
           // @ts-expect-error: macros are dynamically added to the AST so the properties are not typed properly
-          props: block.props,
+          props: block.params,
         };
 
       default:

--- a/editors/blocknote-react/src/blocknote/index.ts
+++ b/editors/blocknote-react/src/blocknote/index.ts
@@ -19,6 +19,7 @@
  */
 
 import { Heading4, Heading5, Heading6 } from "./blocks/Headings";
+import { MACRO_NAME_PREFIX, Macro } from "./utils";
 import translations from "../translations";
 import {
   Block,
@@ -50,7 +51,7 @@ import {
  *
  * @returns The created schema
  */
-function createBlockNoteSchema() {
+function createBlockNoteSchema(macros: Macro[]) {
   // Get rid of some block types
   // eslint-disable-next-line @typescript-eslint/no-unused-vars
   const { audio, video, file, toggleListItem, ...remainingBlockSpecs } =
@@ -68,6 +69,14 @@ function createBlockNoteSchema() {
       Heading4: Heading4.block,
       Heading5: Heading5.block,
       Heading6: Heading6.block,
+
+      // Macros
+      ...Object.fromEntries(
+        macros.map((macro) => [
+          `${MACRO_NAME_PREFIX}${macro.name}`,
+          macro.block.block,
+        ]),
+      ),
     },
   });
 
@@ -97,6 +106,8 @@ type EditorLanguage = keyof typeof locales &
 function querySuggestionsMenuItems(
   editor: EditorType,
   query: string,
+  // TODO: move this elsewhere
+  macros: Macro[],
 ): DefaultReactSuggestionItem[] {
   return filterSuggestionItems(
     combineByGroup(
@@ -109,6 +120,11 @@ function querySuggestionsMenuItems(
       [Heading4, Heading5, Heading6].map((custom) =>
         custom.slashMenuEntry(editor),
       ),
+
+      // Macros
+      macros
+        .filter((macro) => !macro.hidden)
+        .map((macro) => macro.block.slashMenuEntry(editor)),
     ),
     query,
   );

--- a/editors/blocknote-react/src/blocknote/index.ts
+++ b/editors/blocknote-react/src/blocknote/index.ts
@@ -29,6 +29,7 @@ import {
   StyledText,
   combineByGroup,
   defaultBlockSpecs,
+  defaultInlineContentSpecs,
   filterSuggestionItems,
 } from "@blocknote/core";
 import * as locales from "@blocknote/core/locales";
@@ -72,10 +73,26 @@ function createBlockNoteSchema(macros: Macro[]) {
 
       // Macros
       ...Object.fromEntries(
-        macros.map((macro) => [
-          `${MACRO_NAME_PREFIX}${macro.name}`,
-          macro.block.block,
-        ]),
+        macros
+          .filter((macro) => macro.type === "block")
+          .map((macro) => [
+            `${MACRO_NAME_PREFIX}${macro.name}`,
+            macro.block.block,
+          ]),
+      ),
+    },
+
+    inlineContentSpecs: {
+      ...defaultInlineContentSpecs,
+
+      // Macros
+      ...Object.fromEntries(
+        macros
+          .filter((macro) => macro.type === "inline")
+          .map((macro) => [
+            `${MACRO_NAME_PREFIX}${macro.name}`,
+            macro.inlineContent.inlineContent,
+          ]),
       ),
     },
   });
@@ -124,6 +141,8 @@ function querySuggestionsMenuItems(
       // Macros
       macros
         .filter((macro) => !macro.hidden)
+        // Second filter is on a separate line to enable TypeScript's type predicate inference
+        .filter((macro) => macro.type === "block")
         .map((macro) => macro.block.slashMenuEntry(editor)),
     ),
     query,

--- a/editors/blocknote-react/src/blocknote/index.ts
+++ b/editors/blocknote-react/src/blocknote/index.ts
@@ -76,7 +76,7 @@ function createBlockNoteSchema(macros: Macro[]) {
       ...Object.fromEntries(
         filterMap(macros, (macro) =>
           macro.blockNote.type === "block"
-            ? [`${MACRO_NAME_PREFIX}${macro.name}`, macro.blockNote.block]
+            ? [`${MACRO_NAME_PREFIX}${macro.name}`, macro.blockNote.block.block]
             : null,
         ),
       ),
@@ -91,7 +91,7 @@ function createBlockNoteSchema(macros: Macro[]) {
           macro.blockNote.type === "inline"
             ? [
                 `${MACRO_NAME_PREFIX}${macro.name}`,
-                macro.blockNote.inlineContent,
+                macro.blockNote.inlineContent.inlineContent,
               ]
             : null,
         ),

--- a/editors/blocknote-react/src/blocknote/macros/XWikiMacroHtmlBlock.tsx
+++ b/editors/blocknote-react/src/blocknote/macros/XWikiMacroHtmlBlock.tsx
@@ -12,7 +12,6 @@ export const XWikiMacroHtmlBlockMacro = createMacro({
     metadata: "",
   },
   renderType: "block",
-  hasChildren: false,
   render(parameters) {
     return <div dangerouslySetInnerHTML={{ __html: parameters.html }} />;
   },

--- a/editors/blocknote-react/src/blocknote/macros/XWikiMacroHtmlBlock.tsx
+++ b/editors/blocknote-react/src/blocknote/macros/XWikiMacroHtmlBlock.tsx
@@ -12,6 +12,7 @@ export const XWikiMacroHtmlBlockMacro = createMacro({
     metadata: "",
   },
   renderType: "block",
+  hasChildren: false,
   render(parameters) {
     return <div dangerouslySetInnerHTML={{ __html: parameters.html }} />;
   },

--- a/editors/blocknote-react/src/blocknote/macros/XWikiMacroHtmlBlock.tsx
+++ b/editors/blocknote-react/src/blocknote/macros/XWikiMacroHtmlBlock.tsx
@@ -19,7 +19,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 */
 import { createMacro } from "../utils";
 
-export const XWikiMacroHtmlBlockMacro = createMacro({
+export const XWikiMacroHTMLBlockMacro = createMacro({
   name: "XWikiMacroHtmlBlock",
   description: "",
   parameters: {

--- a/editors/blocknote-react/src/blocknote/macros/XWikiMacroHtmlBlock.tsx
+++ b/editors/blocknote-react/src/blocknote/macros/XWikiMacroHtmlBlock.tsx
@@ -1,3 +1,22 @@
+/*
+See the LICENSE file distributed with this work for additional
+information regarding copyright ownership.
+
+This is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2.1 of
+the License, or (at your option) any later version.
+
+This software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this software; if not, write to the Free
+Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
 import { createMacro } from "../utils";
 
 export const XWikiMacroHtmlBlockMacro = createMacro({

--- a/editors/blocknote-react/src/blocknote/macros/XWikiMacroHtmlBlock.tsx
+++ b/editors/blocknote-react/src/blocknote/macros/XWikiMacroHtmlBlock.tsx
@@ -1,0 +1,18 @@
+import { createMacro } from "../utils";
+
+export const XWikiMacroHtmlBlockMacro = createMacro({
+  name: "XWikiMacroHtmlBlock",
+  description: "",
+  parameters: {
+    html: { type: "string" },
+    metadata: { type: "string" },
+  },
+  defaultParameters: {
+    html: "",
+    metadata: "",
+  },
+  renderType: "block",
+  render(parameters) {
+    return <div dangerouslySetInnerHTML={{ __html: parameters.html }} />;
+  },
+});

--- a/editors/blocknote-react/src/blocknote/macros/XWikiMacroInlineHtml.tsx
+++ b/editors/blocknote-react/src/blocknote/macros/XWikiMacroInlineHtml.tsx
@@ -12,6 +12,7 @@ export const XWikiMacroInlineHtmlMacro = createMacro({
     metadata: "",
   },
   renderType: "inline",
+  hasChildren: false,
   render(parameters) {
     return <span dangerouslySetInnerHTML={{ __html: parameters.html }} />;
   },

--- a/editors/blocknote-react/src/blocknote/macros/XWikiMacroInlineHtml.tsx
+++ b/editors/blocknote-react/src/blocknote/macros/XWikiMacroInlineHtml.tsx
@@ -1,0 +1,18 @@
+import { createMacro } from "../utils";
+
+export const XWikiMacroInlineHtmlMacro = createMacro({
+  name: "XWikiMacroInlineHtml",
+  description: "",
+  parameters: {
+    html: { type: "string" },
+    metadata: { type: "string" },
+  },
+  defaultParameters: {
+    html: "",
+    metadata: "",
+  },
+  renderType: "inline",
+  render(parameters) {
+    return <span dangerouslySetInnerHTML={{ __html: parameters.html }} />;
+  },
+});

--- a/editors/blocknote-react/src/blocknote/macros/XWikiMacroInlineHtml.tsx
+++ b/editors/blocknote-react/src/blocknote/macros/XWikiMacroInlineHtml.tsx
@@ -12,7 +12,6 @@ export const XWikiMacroInlineHtmlMacro = createMacro({
     metadata: "",
   },
   renderType: "inline",
-  hasChildren: false,
   render(parameters) {
     return <span dangerouslySetInnerHTML={{ __html: parameters.html }} />;
   },

--- a/editors/blocknote-react/src/blocknote/macros/XWikiMacroInlineHtml.tsx
+++ b/editors/blocknote-react/src/blocknote/macros/XWikiMacroInlineHtml.tsx
@@ -1,3 +1,22 @@
+/*
+See the LICENSE file distributed with this work for additional
+information regarding copyright ownership.
+
+This is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2.1 of
+the License, or (at your option) any later version.
+
+This software is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+Lesser General Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with this software; if not, write to the Free
+Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+02110-1301 USA, or see the FSF site: http://www.fsf.org.
+*/
 import { createMacro } from "../utils";
 
 export const XWikiMacroInlineHtmlMacro = createMacro({

--- a/editors/blocknote-react/src/blocknote/macros/XWikiMacroInlineHtml.tsx
+++ b/editors/blocknote-react/src/blocknote/macros/XWikiMacroInlineHtml.tsx
@@ -19,7 +19,7 @@ Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
 */
 import { createMacro } from "../utils";
 
-export const XWikiMacroInlineHtmlMacro = createMacro({
+export const XWikiMacroInlineHTMLMacro = createMacro({
   name: "XWikiMacroInlineHtml",
   description: "",
   parameters: {

--- a/editors/blocknote-react/src/blocknote/utils.ts
+++ b/editors/blocknote-react/src/blocknote/utils.ts
@@ -117,9 +117,7 @@ type Macro = {
   description: string;
   parameters: Record<string, MacroParameterType>;
   renderType: "inline" | "block";
-
   hidden: boolean;
-  hasChildren: boolean;
 } & MacroConcrete;
 
 /**
@@ -189,7 +187,6 @@ type MacroCreationArgs<Parameters extends Record<string, MacroParameterType>> =
     defaultParameters: FilterUndefined<
       GetConcreteMacroParametersType<Parameters>
     >;
-    hasChildren: boolean;
     hidden?: boolean;
     render: (
       parameters: GetConcreteMacroParametersType<Parameters>,
@@ -204,7 +201,6 @@ function createMacro<Parameters extends Record<string, MacroParameterType>>({
   description,
   parameters,
   defaultParameters,
-  hasChildren,
   hidden,
   render,
   renderType,
@@ -254,7 +250,7 @@ function createMacro<Parameters extends Record<string, MacroParameterType>>({
           block: createCustomBlockSpec({
             config: {
               type,
-              content: hasChildren ? "inline" : "none",
+              content: "none", // TODO: "inline" if hasChildren
               propSchema,
             },
             implementation: {
@@ -277,7 +273,7 @@ function createMacro<Parameters extends Record<string, MacroParameterType>>({
           inlineContent: createCustomInlineContentSpec({
             config: {
               type,
-              content: hasChildren ? "styled" : "none",
+              content: "none", // TODO: "styled" if hasChildren
               propSchema,
             },
             implementation: {
@@ -300,7 +296,6 @@ function createMacro<Parameters extends Record<string, MacroParameterType>>({
     name,
     description,
     parameters,
-    hasChildren,
     hidden: hidden ?? false,
     renderType,
     ...concreteMacro,

--- a/editors/blocknote-react/src/components/BlockNoteViewWrapper.tsx
+++ b/editors/blocknote-react/src/components/BlockNoteViewWrapper.tsx
@@ -33,6 +33,7 @@ import {
   createDictionary,
   querySuggestionsMenuItems,
 } from "../blocknote";
+import { Macro } from "../blocknote/utils";
 import { LinkEditionContext } from "../misc/linkSuggest";
 import { BlockNoteEditorOptions } from "@blocknote/core";
 import "@blocknote/core/fonts/inter.css";
@@ -90,6 +91,11 @@ type BlockNoteViewWrapperProps = {
   content: BlockType[];
 
   /**
+   * Macros to show in the editor
+   */
+  macros: Macro[];
+
+  /**
    * Realtime options
    */
   realtime?: {
@@ -125,6 +131,7 @@ const BlockNoteViewWrapper: React.FC<BlockNoteViewWrapperProps> = ({
   blockNoteOptions,
   theme,
   content,
+  macros,
   realtime,
   onChange,
   lang,
@@ -133,7 +140,7 @@ const BlockNoteViewWrapper: React.FC<BlockNoteViewWrapperProps> = ({
 }: BlockNoteViewWrapperProps) => {
   const { t } = useTranslation();
 
-  const schema = createBlockNoteSchema();
+  const schema = createBlockNoteSchema(macros);
 
   const provider = realtime?.hocusPocus
     ? new HocuspocusProvider(realtime.hocusPocus)
@@ -271,7 +278,9 @@ const BlockNoteViewWrapper: React.FC<BlockNoteViewWrapperProps> = ({
     >
       <SuggestionMenuController
         triggerCharacter={"/"}
-        getItems={async (query) => querySuggestionsMenuItems(editor, query)}
+        getItems={async (query) =>
+          querySuggestionsMenuItems(editor, query, macros)
+        }
       />
 
       <FormattingToolbarController

--- a/editors/blocknote-react/src/components/BlockNoteViewWrapper.tsx
+++ b/editors/blocknote-react/src/components/BlockNoteViewWrapper.tsx
@@ -283,6 +283,8 @@ const BlockNoteViewWrapper: React.FC<BlockNoteViewWrapperProps> = ({
         }
       />
 
+      {/* TODO: suggestions menu for inline macros */}
+
       <FormattingToolbarController
         formattingToolbar={(props) => (
           <CustomFormattingToolbar

--- a/editors/blocknote-react/src/index.tsx
+++ b/editors/blocknote-react/src/index.tsx
@@ -18,8 +18,8 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 import { App } from "./App";
-import { XWikiMacroHtmlBlockMacro } from "./blocknote/macros/XWikiMacroHtmlBlock";
-import { XWikiMacroInlineHtmlMacro } from "./blocknote/macros/XWikiMacroInlineHtml";
+import { XWikiMacroHTMLBlockMacro } from "./blocknote/macros/XWikiMacroHtmlBlock";
+import { XWikiMacroInlineHTMLMacro } from "./blocknote/macros/XWikiMacroInlineHtml";
 import {
   MACRO_NAME_PREFIX,
   Macro,
@@ -71,8 +71,8 @@ function mountBlockNote(
  * Otherwise, you can provide this object's values entirely or select only a few macros and pass them to the setup function.
  */
 const DEFAULT_MACROS = {
-  XWikiMacroHtmlBlock: XWikiMacroHtmlBlockMacro,
-  XWikiMacroInlineHtml: XWikiMacroInlineHtmlMacro,
+  XWikiMacroHTMLBlockMacro,
+  XWikiMacroInlineHTMLMacro,
 };
 
 export { DEFAULT_MACROS, MACRO_NAME_PREFIX, createMacro, mountBlockNote };

--- a/editors/blocknote-react/src/index.tsx
+++ b/editors/blocknote-react/src/index.tsx
@@ -18,11 +18,13 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 import { App } from "./App";
+import { RawHtmlBlockMacro } from "./blocknote/macros/RawHtmlBlock";
+import { RawInlineHtmlMacro } from "./blocknote/macros/RawInlineHtml";
 import { BlockNoteViewWrapperProps } from "./components/BlockNoteViewWrapper";
 import { LinkEditionContext } from "./misc/linkSuggest";
 import { createRoot } from "react-dom/client";
 
-export function mountBlockNote(
+function mountBlockNote(
   containerEl: HTMLElement,
   props: BlockNoteViewWrapperProps,
 ): { unmount: () => void } {
@@ -44,6 +46,11 @@ export function mountBlockNote(
   };
 }
 
-export type { BlockNoteViewWrapperProps, LinkEditionContext };
+const DEFAULT_MACROS = {
+  RawHtmlBlock: RawHtmlBlockMacro,
+  RawInlineHtml: RawInlineHtmlMacro,
+};
 
+export { DEFAULT_MACROS, mountBlockNote };
+export type { BlockNoteViewWrapperProps, LinkEditionContext };
 export * from "./blocknote";

--- a/editors/blocknote-react/src/index.tsx
+++ b/editors/blocknote-react/src/index.tsx
@@ -30,6 +30,16 @@ import { BlockNoteViewWrapperProps } from "./components/BlockNoteViewWrapper";
 import { LinkEditionContext } from "./misc/linkSuggest";
 import { createRoot } from "react-dom/client";
 
+/**
+ * Mount a BlockNote editor inside a DOM container
+ *
+ * @param containerEl - The container to put BlockNote in (must be empty and be a block type component, e.g. `<div>`)
+ * @param props - Properties to setup the editor with
+ *
+ * @returns - An unmount function to properly dispose of the editor
+ *
+ * @since 0.19
+ */
 function mountBlockNote(
   containerEl: HTMLElement,
   props: BlockNoteViewWrapperProps,
@@ -52,6 +62,14 @@ function mountBlockNote(
   };
 }
 
+/**
+ * A set of default macros to use in BlockNote
+ *
+ * These are not enabled by default as some integrations may want to fully disable macros support.
+ * In such case, simply ignore this.
+ *
+ * Otherwise, you can provide this object's values entirely or select only a few macros and pass them to the setup function.
+ */
 const DEFAULT_MACROS = {
   XWikiMacroHtmlBlock: XWikiMacroHtmlBlockMacro,
   XWikiMacroInlineHtml: XWikiMacroInlineHtmlMacro,

--- a/editors/blocknote-react/src/index.tsx
+++ b/editors/blocknote-react/src/index.tsx
@@ -18,8 +18,14 @@
  * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
  */
 import { App } from "./App";
-import { RawHtmlBlockMacro } from "./blocknote/macros/RawHtmlBlock";
-import { RawInlineHtmlMacro } from "./blocknote/macros/RawInlineHtml";
+import { XWikiMacroHtmlBlockMacro } from "./blocknote/macros/XWikiMacroHtmlBlock";
+import { XWikiMacroInlineHtmlMacro } from "./blocknote/macros/XWikiMacroInlineHtml";
+import {
+  MACRO_NAME_PREFIX,
+  Macro,
+  MacroCreationArgs,
+  createMacro,
+} from "./blocknote/utils";
 import { BlockNoteViewWrapperProps } from "./components/BlockNoteViewWrapper";
 import { LinkEditionContext } from "./misc/linkSuggest";
 import { createRoot } from "react-dom/client";
@@ -47,10 +53,15 @@ function mountBlockNote(
 }
 
 const DEFAULT_MACROS = {
-  RawHtmlBlock: RawHtmlBlockMacro,
-  RawInlineHtml: RawInlineHtmlMacro,
+  XWikiMacroHtmlBlock: XWikiMacroHtmlBlockMacro,
+  XWikiMacroInlineHtml: XWikiMacroInlineHtmlMacro,
 };
 
-export { DEFAULT_MACROS, mountBlockNote };
-export type { BlockNoteViewWrapperProps, LinkEditionContext };
+export { DEFAULT_MACROS, MACRO_NAME_PREFIX, createMacro, mountBlockNote };
+export type {
+  BlockNoteViewWrapperProps,
+  LinkEditionContext,
+  Macro,
+  MacroCreationArgs,
+};
 export * from "./blocknote";

--- a/editors/blocknote/src/vue/c-edit-blocknote.vue
+++ b/editors/blocknote/src/vue/c-edit-blocknote.vue
@@ -28,7 +28,10 @@ import {
   DocumentService,
   name as documentServiceName,
 } from "@xwiki/cristal-document-api";
-import { BlocknoteEditor as CBlockNoteView } from "@xwiki/cristal-editors-blocknote-headless";
+import {
+  BlocknoteEditor as CBlockNoteView,
+  DEFAULT_MACROS,
+} from "@xwiki/cristal-editors-blocknote-headless";
 import { ModelReferenceHandlerProvider } from "@xwiki/cristal-model-reference-api";
 import { CArticle } from "@xwiki/cristal-skin";
 import {
@@ -107,6 +110,7 @@ async function loadEditor(currentPage: PageData | undefined): Promise<void> {
     // TODO: make this customizable
     // https://jira.xwiki.org/browse/CRISTAL-457
     lang: "en",
+    macros: Object.values(DEFAULT_MACROS),
   };
 
   editorContent.value = markdownToUniAst.parseMarkdown(currentPage.source);

--- a/editors/blocknote/src/vue/c-edit-blocknote.vue
+++ b/editors/blocknote/src/vue/c-edit-blocknote.vue
@@ -83,7 +83,7 @@ const editorInstance =
 // Tools for UniAst handling
 const converterContext = createConverterContext(container);
 const markdownToUniAst = new MarkdownToUniAstConverter(converterContext);
-const uniAstToMarkdown = new UniAstToMarkdownConverter(converterContext);
+const uniAstToMarkdown = new UniAstToMarkdownConverter();
 
 // Saving status
 const saveStatus = ref<SaveStatus>(SaveStatus.SAVED);


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-44

# Changes

## Description

* Add support for client-side-rendered macros

## Clarifications

* Macros can only be written inside React.js
* They are shown in the slash menu in BlockNote
* A set of default macros are provided by default, but they are not enabled automatically - the integration part needs to explicitly allow them. This allows disabling macros altogether easier.
* The integration part can provide additional macros if required
* Macros are setup during editor initialization, and cannot be changed afterwards
* Macros appear properly in UniAst and are supported in the Markdown converter
* A handful of tests have been added to ensure macros are parsed properly, even using slightly ambiguous syntax
* The parser for XWiki-specific syntax (internal links, internal images, macros) have been completely rewritten and made more robust, using a simple characters loop and properly handling escaping character (`\`).
* Two macros are provided by default: one block and one inilne for rendering raw HTML content, with metadata attached. Will be used from XWiki's side to render macros and preserve the original syntax used to render it before being converted to UniAst.

Besides that, some limitations currently apply:

* Macros cannot be edited for now (will come later)
* Macros cannot have content for now (will come later)
* Inline macros don't appear in BlockNote's slash menu suggestions, as there is no such menu for inline content yet
* Macros cannot have child blocks or inline contents (see https://github.com/TypeCellOS/BlockNote/issues/1540)
* Macros that use a state (e.g. network request, DOM elements, etc.) should cleanup after themselves. They are unmounted following React's specifications, but if they don't cleanup properly some bugs may arise in the editor.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->

# Executed Tests

Existing tests from the parser and new unit tests.
Functional tests to come when more macro features are implemented.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A