### PR TITLE
Fix: remove conflicting realtime property from CBlockNoteView

### DIFF
--- a/editors/blocknote-headless/src/vue/c-blocknote-view.vue
+++ b/editors/blocknote-headless/src/vue/c-blocknote-view.vue
@@ -49,7 +49,10 @@ const {
   collaborationProvider = undefined,
   container,
 } = defineProps<{
-  editorProps: Omit<BlockNoteViewWrapperProps, "content" | "linkEditionCtx">;
+  editorProps: Omit<
+    BlockNoteViewWrapperProps,
+    "content" | "linkEditionCtx" | "realtime"
+  >;
   editorContent: UniAst | Error;
   collaborationProvider?: () => CollaborationInitializer;
   container: Container;


### PR DESCRIPTION
# Jira URL

N/A

# Changes

## Description

* Remove the ability to provide a `realtime` inside `editorProps` in the `c-blocknote-view` component

## Clarifications

* Realtime in BlockNote is now setup using the `collaboration` property in `c-blocknote-view`. The previous `realtime` property in `editorProps` now conflicts with it, so this PR removes it.

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A