### PR TITLE
CRISTAL-584: Support authentication through Nextcloud's login flow v2

### DIFF
--- a/core/authentication/authentication-nextcloud/src/NextcloudLoginFlowAuthenticationManager.ts
+++ b/core/authentication/authentication-nextcloud/src/NextcloudLoginFlowAuthenticationManager.ts
@@ -1,0 +1,154 @@
+/*
+ * See the LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import { AuthenticationManager } from "@xwiki/cristal-authentication-api";
+import { inject, injectable } from "inversify";
+import Cookies from "js-cookie";
+import type { CristalApp, WikiConfig } from "@xwiki/cristal-api";
+import type { UserDetails } from "@xwiki/cristal-authentication-api";
+import type { CookieAttributes } from "js-cookie";
+
+/**
+ * {@link AuthenticationManager} for the Nextcloud backend, using login flow v2.
+ *
+ * @since 0.20
+ */
+@injectable()
+export class NextcloudLoginFlowAuthenticationManager
+  implements AuthenticationManager
+{
+  constructor(@inject("CristalApp") private readonly cristalApp: CristalApp) {}
+
+  private readonly accessTokenCookieKeyPrefix = "accessToken";
+
+  private readonly userIdCookieKeyPrefix = "userId";
+
+  private readonly cookiesOptions: CookieAttributes = {
+    secure: true,
+    sameSite: "strict",
+  };
+
+  async start(): Promise<void> {
+    const config = this.cristalApp.getWikiConfig();
+
+    const loginFlowUrl = `${config.baseURL}/index.php/login/v2`;
+
+    const loginFlowResponse = await fetch(loginFlowUrl, { method: "POST" });
+    const jsonLoginFlowResponse: {
+      poll: { token: string; endpoint: string };
+      login: string;
+    } = await loginFlowResponse.json();
+
+    window.open(jsonLoginFlowResponse.login, "_blank");
+
+    // This interval handles polling Nextcloud for the access token.
+    // It will return a 404 error until the login process has succeeded.
+    const intervalId = setInterval(async () => {
+      const response = await fetch(jsonLoginFlowResponse.poll.endpoint, {
+        method: "POST",
+        body: `token=${jsonLoginFlowResponse.poll.token}`,
+        headers: {
+          "Content-Type": "application/x-www-form-urlencoded",
+        },
+      });
+      if (response.ok) {
+        const jsonResponse: {
+          loginName: string;
+          appPassword: string;
+        } = await response.json();
+        Cookies.set(
+          this.getAccessTokenCookieKey(config.name),
+          btoa(`${jsonResponse.loginName}:${jsonResponse.appPassword}`),
+          this.cookiesOptions,
+        );
+        Cookies.set(
+          this.getUserIdCookieKey(config.name),
+          jsonResponse.loginName,
+          this.cookiesOptions,
+        );
+        clearInterval(intervalId);
+        // We reload the content on successful login.
+        window.location.reload();
+      }
+    }, 3000);
+  }
+
+  async callback(): Promise<void> {
+    console.warn("No callback registered for login flow.");
+  }
+
+  async getUserDetails(): Promise<UserDetails> {
+    const config = this.cristalApp.getWikiConfig();
+
+    const userId = this.getUserIdFromCookie();
+    return {
+      profile: `${config.baseURL}/u/${userId}`,
+      username: userId,
+      name: userId!, // TODO: Find a way to get the display name.
+      avatar: `${config.baseURL}/avatar/${userId}/64`,
+    };
+  }
+
+  async logout(): Promise<void> {
+    Cookies.remove(this.getAccessTokenCookieKey());
+    Cookies.remove(this.getUserIdCookieKey());
+  }
+
+  async getAuthorizationHeader(): Promise<string | undefined> {
+    const isAuthenticated = await this.isAuthenticated();
+    if (isAuthenticated) {
+      return `Basic ${Cookies.get(this.getAccessTokenCookieKey())}`;
+    }
+  }
+
+  async isAuthenticated(): Promise<boolean> {
+    return this.getAccessToken() !== undefined;
+  }
+
+  getUserId(): string | undefined {
+    return this.getUserIdFromCookie();
+  }
+
+  private getAccessToken() {
+    return Cookies.get(this.getAccessTokenCookieKey());
+  }
+
+  private getAccessTokenCookieKey(configName?: string) {
+    const config = this.resolveConfig(configName);
+    return `${this.accessTokenCookieKeyPrefix}-login-flow-${config?.baseURL}`;
+  }
+
+  private getUserIdCookieKey(configName?: string) {
+    const config = this.resolveConfig(configName);
+    return `${this.userIdCookieKeyPrefix}-login-flow-${config?.baseURL}`;
+  }
+
+  private resolveConfig(configName?: string): WikiConfig {
+    if (configName !== undefined) {
+      return this.cristalApp.getAvailableConfigurations().get(configName)!;
+    } else {
+      return this.cristalApp.getWikiConfig();
+    }
+  }
+
+  private getUserIdFromCookie() {
+    return Cookies.get(this.getUserIdCookieKey());
+  }
+}

--- a/core/authentication/authentication-nextcloud/src/index.ts
+++ b/core/authentication/authentication-nextcloud/src/index.ts
@@ -19,6 +19,7 @@
  */
 
 import { NextcloudBasicAuthenticationManager } from "./NextcloudBasicAuthenticationManager";
+import { NextcloudLoginFlowAuthenticationManager } from "./NextcloudLoginFlowAuthenticationManager";
 import { NextcloudOAuth2AuthenticationManager } from "./NextcloudOAuth2AuthenticationManager";
 import { NextcloudAuthenticationState } from "@xwiki/cristal-authentication-nextcloud-state";
 import type { AuthenticationManager } from "@xwiki/cristal-authentication-api";
@@ -31,6 +32,11 @@ export class ComponentInit {
       .to(NextcloudBasicAuthenticationManager)
       .inSingletonScope()
       .whenNamed("Nextcloud/basic");
+    container
+      .bind<AuthenticationManager>("AuthenticationManager")
+      .to(NextcloudLoginFlowAuthenticationManager)
+      .inSingletonScope()
+      .whenNamed("Nextcloud/login-flow");
     container
       .bind<AuthenticationManager>("AuthenticationManager")
       .to(NextcloudOAuth2AuthenticationManager)

--- a/electron/authentication/authentication-nextcloud/authentication-nextcloud-preload/src/index.ts
+++ b/electron/authentication/authentication-nextcloud/authentication-nextcloud-preload/src/index.ts
@@ -41,6 +41,12 @@ contextBridge.exposeInMainWorld("authenticationNextcloud", {
     });
   },
 
+  async loginFlow(baseUrl: string): Promise<void> {
+    return ipcRenderer.invoke("authentication:nextcloud:loginFlow", {
+      baseUrl,
+    });
+  },
+
   async isLoggedIn(mode: string): Promise<boolean> {
     return ipcRenderer.invoke("authentication:nextcloud:isLoggedIn", {
       mode,

--- a/electron/authentication/authentication-nextcloud/authentication-nextcloud-renderer/src/NextcloudLoginFlowAuthenticationManager.ts
+++ b/electron/authentication/authentication-nextcloud/authentication-nextcloud-renderer/src/NextcloudLoginFlowAuthenticationManager.ts
@@ -1,0 +1,93 @@
+/*
+ * See the LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import { UserDetails } from "@xwiki/cristal-authentication-api";
+import { inject, injectable } from "inversify";
+import type { CristalApp } from "@xwiki/cristal-api";
+import type { AuthenticationManager } from "@xwiki/cristal-authentication-api";
+
+interface AuthenticationWindow extends Window {
+  authenticationNextcloud: {
+    loginFlow: (baseUrl: string) => Promise<void>;
+
+    isLoggedIn(mode: string): Promise<boolean>;
+
+    getUserDetails(mode: string): Promise<UserDetails>;
+
+    getAuthorizationValue(mode: string): Promise<{
+      tokenType: string;
+      accessToken: string;
+    }>;
+
+    logout(mode: string): Promise<void>;
+
+    refreshToken: (
+      baseUrl: string,
+      authenticationBaseUrl: string,
+    ) => Promise<void>;
+
+    getUserId: () => string | undefined;
+  };
+}
+declare const window: AuthenticationWindow;
+
+@injectable()
+export class NextcloudLoginFlowAuthenticationManager
+  implements AuthenticationManager
+{
+  constructor(@inject("CristalApp") private readonly cristalApp: CristalApp) {}
+
+  async start(): Promise<void> {
+    const config = this.cristalApp.getWikiConfig();
+
+    await window.authenticationNextcloud.loginFlow(config.baseURL);
+  }
+
+  async callback(): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  async getAuthorizationHeader(): Promise<string | undefined> {
+    const authenticated = await this.isAuthenticated();
+    if (authenticated) {
+      const { tokenType, accessToken } =
+        await window.authenticationNextcloud.getAuthorizationValue(
+          "login-flow",
+        );
+      return `${tokenType} ${accessToken}`;
+    }
+  }
+
+  async isAuthenticated(): Promise<boolean> {
+    return window.authenticationNextcloud.isLoggedIn("login-flow");
+  }
+
+  async getUserDetails(): Promise<UserDetails> {
+    return window.authenticationNextcloud.getUserDetails("login-flow");
+  }
+
+  async logout(): Promise<void> {
+    await window.authenticationNextcloud.logout("login-flow");
+  }
+
+  getUserId(): string | undefined {
+    return window.authenticationNextcloud.getUserId();
+  }
+}

--- a/electron/authentication/authentication-nextcloud/authentication-nextcloud-renderer/src/index.ts
+++ b/electron/authentication/authentication-nextcloud/authentication-nextcloud-renderer/src/index.ts
@@ -19,6 +19,7 @@
  */
 
 import { NextcloudBasicAuthenticationManager } from "./NextcloudBasicAuthenticationManager";
+import { NextcloudLoginFlowAuthenticationManager } from "./NextcloudLoginFlowAuthenticationManager";
 import { NextcloudOAuth2AuthenticationManager } from "./NextcloudOAuth2AuthenticationManager";
 import { NextcloudAuthenticationState } from "@xwiki/cristal-authentication-nextcloud-state";
 import type { AuthenticationManager } from "@xwiki/cristal-authentication-api";
@@ -31,6 +32,11 @@ class ComponentInit {
       .to(NextcloudBasicAuthenticationManager)
       .inSingletonScope()
       .whenNamed("Nextcloud/basic");
+    container
+      .bind<AuthenticationManager>("AuthenticationManager")
+      .to(NextcloudLoginFlowAuthenticationManager)
+      .inSingletonScope()
+      .whenNamed("Nextcloud/login-flow");
     container
       .bind<AuthenticationManager>("AuthenticationManager")
       .to(NextcloudOAuth2AuthenticationManager)


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-584

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

* Implement NextcloudLoginFlowAuthenticationManager

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

This PR adds support for the authentication flow mentioned in https://docs.nextcloud.com/server/latest/developer_manual/client_apis/LoginFlow/index.html#login-flow-v2.
Please note that, due to CORS handling, it might not be usable from a browser (see https://github.com/nextcloud/server/issues/34898).
The electron implementation opens the login page externally to avoid possible issues related to content security policies configured on the host.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A