### PR TITLE
CRISTAL-576: homePage is set to the empty string when editing a configuration

### DIFF
--- a/core/settings/settings-configurations-ui/src/vue/ConfigurationEdit.vue
+++ b/core/settings/settings-configurations-ui/src/vue/ConfigurationEdit.vue
@@ -101,8 +101,18 @@ async function submit() {
     storageRoot: storageRoot.value,
     realtimeURL: realtimeUrl.value,
     authenticationBaseURL: authenticationBaseUrl.value,
-    editor: editor.value ? editor.value : undefined,
+    editor: editor.value,
   });
+
+  // Clean up all empty and null properties.
+  Object.keys(configuration.value!).forEach(
+    (k) =>
+      (configuration.value![k] =
+        configuration.value![k] || configuration.value![k] === false
+          ? configuration.value![k]
+          : undefined),
+  );
+
   settingsManager
     .get(ConfigurationsSettings)!
     .content.set(props.configurationName, configuration.value!);


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/CRISTAL-576

# Changes

## Description

This adds a simple cleaning for empty properties before they are used.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->
N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A