### PR TITLE
CRISTAL-617: Show a message before leaving with unsaved content in BlockNote

### DIFF
--- a/editors/blocknote/langs/translation-en.json
+++ b/editors/blocknote/langs/translation-en.json
@@ -1,3 +1,4 @@
 {
-  "blocknote.editor.save.error": "Failed to save the page."
+  "blocknote.editor.save.error": "Failed to save the page.",
+  "blocknote.editor.save.unsavedChanges": "You have unsaved changes. Do you really want to quit?"
 }

--- a/editors/blocknote/src/vue/c-edit-blocknote.vue
+++ b/editors/blocknote/src/vue/c-edit-blocknote.vue
@@ -37,7 +37,7 @@ import {
 } from "@xwiki/cristal-uniast-markdown";
 import { createConverterContext } from "@xwiki/cristal-uniast-utils";
 import { debounce } from "lodash-es";
-import { inject, ref, shallowRef, useTemplateRef, watch } from "vue";
+import { inject, onMounted, ref, shallowRef, useTemplateRef, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import type { AlertsService } from "@xwiki/cristal-alerts-api";
 import type { CristalApp, PageData } from "@xwiki/cristal-api";
@@ -234,6 +234,20 @@ watch(
     }
   }, 500),
 );
+
+function beforeUnload(evt: BeforeUnloadEvent): string | void {
+  if (saveStatus.value !== SaveStatus.SAVED) {
+    evt.preventDefault();
+
+    // NOTE: the message won't actually be shown in most browsers nowadays, it will be replaced with a generic message instead.
+    // This is not a bug.
+    return t("blocknote.editor.save.unsavedChanges");
+  }
+}
+
+onMounted(() => {
+  window.addEventListener("beforeunload", beforeUnload);
+});
 </script>
 
 <template>


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-617

# Changes

## Description

* Show a confirmation dialog when quitting BlockNote with unsaved changes
 
## Clarifications

* Only applies to the full-blown BlockNote editor package, not to the `blocknote-headless` part given that each integration may desire to customize this behavior

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A