### PR TITLE
CRISTAL-619: show hierarchy in link editor

### DIFF
--- a/editors/blocknote-react/src/components/links/LinkEditor.tsx
+++ b/editors/blocknote-react/src/components/links/LinkEditor.tsx
@@ -19,12 +19,19 @@
  */
 import { createLinkSuggestor } from "../../misc/linkSuggest";
 import { SearchBox } from "../SearchBox";
-import { Button, Input, Stack, Text, useCombobox } from "@mantine/core";
+import {
+  Breadcrumbs,
+  Button,
+  Input,
+  Stack,
+  Text,
+  useCombobox,
+} from "@mantine/core";
 import { tryFallible } from "@xwiki/cristal-fn-utils";
 import { LinkType } from "@xwiki/cristal-link-suggest-api";
 import { useCallback, useState } from "react";
 import { useTranslation } from "react-i18next";
-import { RiText } from "react-icons/ri";
+import { RiFileLine, RiText } from "react-icons/ri";
 import type { LinkEditionContext } from "../../misc/linkSuggest";
 
 type LinkData = {
@@ -94,7 +101,18 @@ export const LinkEditor: React.FC<LinkEditorProps> = ({
             ),
           )
         }
-        renderSuggestion={(label) => <Text>{label.title}</Text>}
+        renderSuggestion={(link) => (
+          <Stack justify="center">
+            <Text>
+              <RiFileLine /> {link.title}
+            </Text>
+            <Breadcrumbs c="gray">
+              {link.segments.map((segment, i) => (
+                <Text key={`${i}${segment}`}>{segment}</Text>
+              ))}
+            </Breadcrumbs>
+          </Stack>
+        )}
         onSelect={(url) => (creationMode ? submit({ url }) : setUrl(url))}
         onSubmit={(url) => submit({ url })}
       />


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/projects/CRISTAL/issues/CRISTAL-619

# Changes

## Description

* Show the pages' hierarchy in the link suggestions list

## Clarifications

N/A

# Screenshots & Video

<img width="371" height="305" alt="image" src="https://github.com/user-attachments/assets/7029aec0-b506-4bbc-b793-59c771d4392c" />

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A