### PR TITLE
CRISTAL-616: pre-fill image selector popover with current URL / entity name

### DIFF
--- a/editors/blocknote-react/src/components/images/ImageFilePanel.tsx
+++ b/editors/blocknote-react/src/components/images/ImageFilePanel.tsx
@@ -47,7 +47,11 @@ export const ImageFilePanel: React.FC<ImageFilePanelProps> = ({
     // By default file panels don't have any styling and just "float", unstyled, above the editor
     // So we put some container to make it stand out from the editor's content
     <Paper shadow="md" p="sm">
-      <ImageSelector linkEditionCtx={linkEditionCtx} onSelected={updateImage} />
+      <ImageSelector
+        linkEditionCtx={linkEditionCtx}
+        currentSelection={image.props.url}
+        onSelected={updateImage}
+      />
     </Paper>
   );
 };

--- a/editors/blocknote-react/src/components/images/ImageSelector.tsx
+++ b/editors/blocknote-react/src/components/images/ImageSelector.tsx
@@ -34,7 +34,7 @@ import {
   AttachmentReference,
   DocumentReference,
 } from "@xwiki/cristal-model-api";
-import { useCallback, useEffect, useRef } from "react";
+import { useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { RiAttachmentLine } from "react-icons/ri";
 import type {
@@ -44,13 +44,27 @@ import type {
 
 export type ImageSelectorProps = {
   linkEditionCtx: LinkEditionContext;
+  currentSelection?: string;
   onSelected: (url: string) => void;
 };
 
 export const ImageSelector: React.FC<ImageSelectorProps> = ({
   linkEditionCtx,
+  currentSelection,
   onSelected,
 }) => {
+  const initialQuery = useMemo(() => {
+    if (!currentSelection) {
+      return null;
+    }
+
+    const entityRef = linkEditionCtx.remoteURLParser.parse(currentSelection);
+
+    return entityRef
+      ? linkEditionCtx.modelReferenceHandler.getTitle(entityRef)
+      : currentSelection;
+  }, [currentSelection]);
+
   const { t } = useTranslation();
 
   const fileUploadRef = useRef<HTMLButtonElement>(null);
@@ -125,7 +139,7 @@ export const ImageSelector: React.FC<ImageSelectorProps> = ({
 
   // Start a first empty search on the first load, to not let the results empty.
   useEffect(() => {
-    searchAttachments("");
+    searchAttachments(initialQuery ?? "");
   }, []);
 
   return (
@@ -146,6 +160,7 @@ export const ImageSelector: React.FC<ImageSelectorProps> = ({
 
       <SearchBox
         placeholder={t("blocknote.imageSelector.placeholder")}
+        initialValue={initialQuery ?? ""}
         getSuggestions={searchAttachments}
         renderSuggestion={(suggestion) => (
           <Flex gap="sm">

--- a/editors/blocknote-react/src/components/images/ImageSelector.tsx
+++ b/editors/blocknote-react/src/components/images/ImageSelector.tsx
@@ -61,7 +61,7 @@ export const ImageSelector: React.FC<ImageSelectorProps> = ({
     const entityRef = linkEditionCtx.remoteURLParser.parse(currentSelection);
 
     return entityRef
-      ? linkEditionCtx.modelReferenceHandler.getTitle(entityRef)
+      ? linkEditionCtx.modelReferenceSerializer.serialize(entityRef)
       : currentSelection;
   }, [currentSelection]);
 

--- a/editors/blocknote-react/src/components/images/ImageSelector.tsx
+++ b/editors/blocknote-react/src/components/images/ImageSelector.tsx
@@ -29,6 +29,7 @@ import {
   Text,
   VisuallyHidden,
 } from "@mantine/core";
+import { tryFallible } from "@xwiki/cristal-fn-utils";
 import { LinkType } from "@xwiki/cristal-link-suggest-api";
 import {
   AttachmentReference,
@@ -59,9 +60,11 @@ export const ImageSelector: React.FC<ImageSelectorProps> = ({
       return ["", null];
     }
 
-    const entityRef = linkEditionCtx.remoteURLParser.parse(currentSelection);
+    const entityRef = tryFallible(() =>
+      linkEditionCtx.remoteURLParser.parse(currentSelection),
+    );
 
-    if (!entityRef) {
+    if (!entityRef || entityRef instanceof Error) {
       return [currentSelection, null];
     }
 

--- a/editors/blocknote-react/src/components/images/ImageSelector.tsx
+++ b/editors/blocknote-react/src/components/images/ImageSelector.tsx
@@ -54,7 +54,7 @@ export const ImageSelector: React.FC<ImageSelectorProps> = ({
   currentSelection,
   onSelected,
 }) => {
-  const [initialQuery, initialEntitySegments] = useMemo(() => {
+  const [initialQuery, selectedEntityPath] = useMemo(() => {
     if (!currentSelection) {
       return ["", null];
     }
@@ -72,7 +72,12 @@ export const ImageSelector: React.FC<ImageSelectorProps> = ({
 
     const segments = documentReference.space?.names.slice(0) ?? [];
 
-    return [linkEditionCtx.modelReferenceHandler.getTitle(entityRef), segments];
+    return [
+      "",
+      segments.concat([
+        linkEditionCtx.modelReferenceHandler.getTitle(entityRef)!,
+      ]),
+    ];
   }, [currentSelection]);
 
   const { t } = useTranslation();
@@ -198,10 +203,12 @@ export const ImageSelector: React.FC<ImageSelectorProps> = ({
         onSubmit={onSelected}
       />
 
-      {initialEntitySegments && (
-        <Breadcrumbs c="gray" pt="md" ml="xl" fz="xs" separatorMargin="0.33rem">
-          {initialEntitySegments.map((segment, i) => (
-            <Text key={`${i}${segment}`}>{segment}</Text>
+      {selectedEntityPath && (
+        <Breadcrumbs c="gray" pt="md" separatorMargin="0.33rem">
+          {selectedEntityPath.map((segment, i) => (
+            <Text fz="0.9rem" key={`${i}${segment}`}>
+              {segment}
+            </Text>
           ))}
         </Breadcrumbs>
       )}


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-616

# Changes

## Description

* When editing an image in the editor, pre-fill the search field with the image's entity name (or current URL)

## Clarifications

N/A

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A