### PR TITLE
CRISTAL-620: Attachment suggestion does not show entities context with BlockNote & NextCloud

### DIFF
--- a/core/model/model-reference/model-reference-nextcloud/src/nextcloudModelReferenceParser.ts
+++ b/core/model/model-reference/model-reference-nextcloud/src/nextcloudModelReferenceParser.ts
@@ -117,7 +117,7 @@ export class NextcloudModelReferenceParser implements ModelReferenceParser {
             : documentName,
           new SpaceReference(
             undefined,
-            ...segments.slice(0, segments.length - 3),
+            ...segments.slice(0, segments.length - 2),
           ),
         ),
       );


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/projects/CRISTAL/issues/CRISTAL-620

# Changes

## Description

* Correctly show leaf page in segments list when searching for images in BlockNote with NextCloud backend
* Actually also fixes it for TipTap (seems like there was a bug with TipTap as well to begin with)
* The bugfix was extremely trivial but pretty hard to debug, which makes me thing it would be a really nice addition to have some kind of docs (even basic ones) to browse through Cristal's now pretty large codebase

## Clarifications

N/A

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A