### PR TITLE
CRISTAL-693: Can't load page references with dots character on XWiki

### DIFF
--- a/core/backends/backend-xwiki/src/xwikiStorage.ts
+++ b/core/backends/backend-xwiki/src/xwikiStorage.ts
@@ -396,11 +396,14 @@ export class XWikiStorage extends AbstractStorage {
 
   private buildPageRestBaseURL(page: string, segments: string[]) {
     const url = this.wikiConfig.baseURL;
-    const referenceParts = page.split(".");
+    // We split around dots that are not escaped.
+    // (i.e., not preceded by an odd number of backslashes)
+    const referenceParts = page.split(/(?<=(?<!\\)(?:\\\\)*)\./);
     for (let i = 0; i < referenceParts.length; i++) {
       const segment = i < referenceParts.length - 1 ? "spaces" : "pages";
       segments.push(segment);
-      segments.push(referenceParts[i]);
+      // We unescape previously escaped dots, if any.
+      segments.push(referenceParts[i].replace(/\\\./g, "."));
     }
 
     return `${url}/${segments.join("/")}`;

--- a/sources/xwiki/mock-server/src/index.ts
+++ b/sources/xwiki/mock-server/src/index.ts
@@ -62,6 +62,7 @@ app.get(
 
     const id: string = (req.params.page as unknown as Array<string>)
       .filter((_v: string, i: number) => i % 2 == 0)
+      .map((v: string) => v.replace(/\./g, "\\.")) // Escape dots
       .join(".");
 
     let page: string = "";

--- a/web/e2e/main-page.spec.ts
+++ b/web/e2e/main-page.spec.ts
@@ -301,6 +301,13 @@ configs.forEach(
       });
     });
 
+    test(`[${name}] can load pages with dots`, async ({ page }) => {
+      await page.goto("Localhost/#/Main.Page%5C.With%5C.Dots/view");
+
+      const locator = page.locator("#xwikicontent");
+      await expect(locator).toContainText("Welcome to Main.Page\\.With\\.Dots");
+    });
+
     if (offlineDefaultPage) {
       test(`[${name}] offline actually fetch updated versions`, async ({
         page,


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/CRISTAL-693

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->

This PR fixes the regression and includes an integration test.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->

N/A

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
This was tested manually and through the new test, before and after the patch.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A