### PR TITLE
CRISTAL-822: There is a 404 alert error when creating a page successfully

### DIFF
--- a/core/backends/backend-xwiki/src/__tests__/xwikiStorage.test.ts
+++ b/core/backends/backend-xwiki/src/__tests__/xwikiStorage.test.ts
@@ -69,7 +69,13 @@ describe("getPageFromViewURL", () => {
   it("fetch page with dots", async () => {
     global.fetch = vi.fn(() =>
       Promise.resolve({
-        json: () => Promise.resolve({}),
+        ok: true,
+        json: () =>
+          Promise.resolve({
+            hierarchy: {
+              items: [{ name: "" }],
+            },
+          }),
       } as Response),
     );
     await xwikiStorage.getPageContent(

--- a/core/backends/backend-xwiki/src/xwikiStorage.ts
+++ b/core/backends/backend-xwiki/src/xwikiStorage.ts
@@ -161,18 +161,15 @@ export class XWikiStorage extends AbstractStorage {
       },
     });
 
-    let json;
-    try {
-      json = await response.json();
-      if (!response.ok) {
-        // TODO: Fix CRISTAL-383 (Error messages in Storages are not translated)
-        this.alertsServiceProvider
-          .get()
-          .error(`Could not load page ${page}. Reason: ${json.message}`);
-        return undefined;
-      }
-    } catch {
+    const json = await response.json();
+    if (response.status == 404) {
       // Return undefined in case of missing page.
+      return undefined;
+    } else if (!response.ok) {
+      // TODO: Fix CRISTAL-383 (Error messages in Storages are not translated)
+      this.alertsServiceProvider
+        .get()
+        .error(`Could not load page ${page}. Reason: ${json.message}`);
       return undefined;
     }
 

--- a/sources/xwiki/mock-server/src/index.ts
+++ b/sources/xwiki/mock-server/src/index.ts
@@ -103,7 +103,7 @@ app.get(
   "/xwiki/rest/wikis/xwiki/spaces/Main/spaces/NewPage/pages/WebHome",
   (_: Request, res: Response) => {
     res.appendHeader("Access-Control-Allow-Origin", "*");
-    res.sendStatus(404);
+    res.status(404).json({});
   },
 );
 
@@ -114,7 +114,7 @@ app.get(
 
     if (newNewPage2) {
       newNewPage2 = false;
-      res.sendStatus(404);
+      res.status(404).json({});
     } else {
       res.json({
         rawTitle: "Main.NewPage2.WebHome",


### PR DESCRIPTION
# Jira URL

<!-- Add the link to the corresponding JIRA issue referenced in a commit message. Unless this is a [Misc] commit,
see https://dev.xwiki.org/xwiki/bin/view/Community/DevelopmentPractices#HRule:Don27tcreateunnecessaryissues
-->
https://jira.xwiki.org/browse/CRISTAL-822

# Changes

## Description

<!-- Describe the main changes brought in this PR. -->
Fix the issue and update existing tests.

## Clarifications

<!-- Provide extra hints to make it easier to understand the PR. Those could be:
* Explanation of choices made in this PR
* Anchor towards extra resources needed to understand the context of this PR (e.g., a forum proposal).
* Links to other issues this issue depends on
-->
The previous behavior of `XWikiStorage` relied on `response.json()` failing when the page did not exist, and catching the exception. But this no longer happens since we dropped the custom Cristal REST endpoint in https://jira.xwiki.org/browse/CRISTAL-812, so the `try ... catch` no longer worked.

# Screenshots & Video

<!-- If this PR introduces any UI change, it's recommended to highlight it with before/after screenshots 
or even a screen recording for complex interactions. 
-->
N/A

# Executed Tests

<!-- Especially important for regression fixes. 
Indicate how changes were tested (e.g., what maven commands were run to validate them).
-->
Tested manually and ran the test suite.

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * N/A