### PR TITLE
XWIKI-24231: Expose the insert macro action

### DIFF
--- a/editors/blocknote/src/vue/c-edit-blocknote.vue
+++ b/editors/blocknote/src/vue/c-edit-blocknote.vue
@@ -136,6 +136,11 @@ const contextForMacros: ContextForMacros = {
   openParamsEditor(/*macro, params, update*/) {
     alert("TODO: params editor for macros in Cristal");
   },
+
+  openInsertionEditor(prefill) {
+    console.debug({ prefill });
+    alert("TODO: insertion editor for macros in Cristal");
+  },
 };
 
 /**
@@ -332,7 +337,7 @@ onBeforeRouteLeave(() => {
                 ref="editorInstance"
                 :editor-props
                 :editor-content
-                :container
+                :deps-container="container"
                 :collaboration
                 :macros="{
                   ctx: contextForMacros,


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/XWIKI-24231

Sister PR in xwiki-platform: https://github.com/xwiki/xwiki-platform/pull/5539

# Changes

## Description

* Add a macro insertion mechanism in the toolbar in toolbar and in the quick actions dropdown

## Clarifications

* Just like for link edition, Cristal only has a placeholder for now, actual implementation depends on the caller

# Screenshots & Video

N/A

# Executed Tests

N/A

# Expected merging strategy

* Prefers squash: Yes <!-- No — Explain why. -->
* Backport on branches:
  * 