### PR TITLE
CRISTALNC-36: New page modal parent location field

### DIFF
--- a/core/navigation-tree/navigation-tree-ui/package.json
+++ b/core/navigation-tree/navigation-tree-ui/package.json
@@ -46,11 +46,16 @@
   },
   "devDependencies": {
     "@types/async-lock": "catalog:",
+    "@vue/test-utils": "catalog:",
     "@xwiki/cristal-dev-config": "workspace:*",
+    "@xwiki/cristal-dev-test-utils": "workspace:*",
     "@xwiki/platform-tool-apiextractorconfig": "catalog:",
     "@xwiki/platform-tool-tsconfig": "catalog:",
+    "inversify": "catalog:",
     "typescript": "catalog:",
     "vite": "catalog:",
+    "vitest": "catalog:",
+    "vitest-mock-extended": "catalog:",
     "vue": "catalog:",
     "vue-tsc": "catalog:"
   },

--- a/core/navigation-tree/navigation-tree-ui/src/vue/NavigationTreeSelect.vue
+++ b/core/navigation-tree/navigation-tree-ui/src/vue/NavigationTreeSelect.vue
@@ -21,7 +21,7 @@
 import NavigationTree from "./NavigationTree.vue";
 import messages from "../translations";
 import { SpaceReference } from "@xwiki/platform-model-api";
-import { inject, onBeforeMount, ref, watch } from "vue";
+import { computed, inject, onBeforeMount, ref, useId, watch } from "vue";
 import { useI18n } from "vue-i18n";
 import type { CristalApp } from "@xwiki/platform-api";
 import type { DocumentService } from "@xwiki/platform-document-api";
@@ -66,6 +66,12 @@ const currentPageReference: Ref<DocumentReference | undefined> =
 
 const openedLocationDialog: Ref<boolean> = ref(false);
 const hierarchy: Ref<Array<PageHierarchyItem>> = ref([]);
+// The location chosen in the tree, only applied to the model once the user
+// confirms with the Select button.
+const pendingLocation: Ref<SpaceReference | undefined> = ref(undefined);
+
+const changeLocationButtonId = useId();
+const selectButtonId = useId();
 
 const { t } = useI18n({
   messages,
@@ -89,25 +95,49 @@ watch(model, async (newLocation) => {
 });
 
 onBeforeMount(async () => {
-  const currentSpaceReference = currentPageReference.value!.space;
-  model.value = currentSpaceReference;
-  if (currentSpaceReference) {
+  // A location provided by the caller takes precedence over the default
+  // (the space of the current page).
+  const initialLocation = model.value ?? currentPageReference.value!.space;
+  model.value = initialLocation;
+  if (initialLocation) {
     hierarchy.value = await hierarchyResolver.getPageHierarchy(
-      currentPageReference.value!.space!,
+      initialLocation,
       false,
     );
   }
 });
 
 async function nodeClickAction(node: NavigationTreeNode) {
-  model.value = node.location;
+  pendingLocation.value = node.location;
 }
+
+function selectLocation() {
+  if (pendingLocation.value) {
+    model.value = pendingLocation.value;
+  }
+  openedLocationDialog.value = false;
+}
+
+// Start each visit to the location dialog from a clean slate so a choice
+// abandoned by closing the dialog is not applied on the next confirmation.
+watch(openedLocationDialog, (opened) => {
+  if (opened) {
+    pendingLocation.value = undefined;
+  }
+});
+
+// The breadcrumb is a plain display of the selected location: the urls are
+// stripped so that its segments are not rendered as links, otherwise clicking
+// one would navigate away while the surrounding dialog stays open.
+const displayHierarchy = computed(() =>
+  hierarchy.value.map(({ label }) => ({ label })),
+);
 </script>
 
 <template>
   <x-text-field :label="label" :help="help" modelValue=" " readonly>
     <template #default>
-      <XBreadcrumb :items="hierarchy"></XBreadcrumb>
+      <XBreadcrumb :items="displayHierarchy"></XBreadcrumb>
     </template>
   </x-text-field>
   <XDialog
@@ -116,7 +146,7 @@ async function nodeClickAction(node: NavigationTreeNode) {
     :title="t('navigation.tree.select.location.label')"
   >
     <template #activator>
-      <x-btn id="change-page-location-button" size="small" color="secondary">
+      <x-btn :id="changeLocationButtonId" size="small" color="secondary">
         {{ t("navigation.tree.select.location.label") }}
       </x-btn>
     </template>
@@ -128,7 +158,7 @@ async function nodeClickAction(node: NavigationTreeNode) {
       ></navigation-tree>
     </template>
     <template #footer>
-      <XBtn variant="primary" @click="openedLocationDialog = false">
+      <XBtn :id="selectButtonId" variant="primary" @click="selectLocation">
         {{ t("navigation.tree.select.location.select") }}
       </XBtn>
     </template>

--- a/core/navigation-tree/navigation-tree-ui/src/vue/__tests__/NavigationTreeSelect.test.ts
+++ b/core/navigation-tree/navigation-tree-ui/src/vue/__tests__/NavigationTreeSelect.test.ts
@@ -1,0 +1,258 @@
+/**
+ * See the LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import NavigationTreeSelect from "../NavigationTreeSelect.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { mockI18n } from "@xwiki/cristal-dev-test-utils";
+import { DocumentReference, SpaceReference } from "@xwiki/platform-model-api";
+import { Container } from "inversify";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { ref } from "vue";
+import type { DocumentService } from "@xwiki/platform-document-api";
+import type {
+  PageHierarchyResolver,
+  PageHierarchyResolverProvider,
+} from "@xwiki/platform-hierarchy-api";
+import type {
+  ModelReferenceHandler,
+  ModelReferenceHandlerProvider,
+} from "@xwiki/platform-model-reference-api";
+
+vi.mock("vue-i18n");
+
+const XBreadcrumbStub = {
+  props: {
+    items: Array,
+  },
+  template: `<span
+    v-for="item in items"
+    class="breadcrumb-segment"
+    :data-url="item.url"
+    >{{ item.label }}</span>`,
+};
+
+const NavigationTreeStub = {
+  props: ["nodeClickAction", "includeTerminals", "showRootNode"],
+  template: `<div class="navigation-tree-stub"></div>`,
+};
+
+const XTextFieldStub = {
+  props: {
+    label: String,
+    help: String,
+    modelValue: String,
+    readonly: Boolean,
+  },
+  template: `<div>
+    <span class="label">{{ label }}</span>
+    <input :value="modelValue" :readonly="readonly" />
+    <slot></slot>
+    <span class="help">{{ help }}</span>
+  </div>`,
+};
+
+// The successive references for which a page hierarchy was requested, reset
+// on each mount.
+let hierarchyRequests: unknown[] = [];
+
+// eslint-disable-next-line max-statements
+function mountNavigationTreeSelect(options?: { location?: SpaceReference }) {
+  const containerMock = mock<Container>();
+
+  hierarchyRequests = [];
+  const mockHierarchyResolver = mock<PageHierarchyResolver>();
+  mockHierarchyResolver.getPageHierarchy.mockImplementation(async (page) => {
+    hierarchyRequests.push(page);
+    return [
+      { label: "Home", pageId: "Home", url: "/Home" },
+      { label: "Deep Space", pageId: "Home.Deep", url: "/Home/Deep" },
+    ];
+  });
+  const mockHierarchyResolverProvider = mock<PageHierarchyResolverProvider>();
+  mockHierarchyResolverProvider.get.mockReturnValue(mockHierarchyResolver);
+
+  const mockReferenceHandler = mock<ModelReferenceHandler>();
+  mockReferenceHandler.createDocumentReference.mockImplementation(
+    (name, space) => new DocumentReference(name, space),
+  );
+  const mockReferenceHandlerProvider = mock<ModelReferenceHandlerProvider>();
+  mockReferenceHandlerProvider.get.mockReturnValue(mockReferenceHandler);
+
+  const mockDocumentService = mock<DocumentService>();
+  mockDocumentService.getCurrentDocumentReference.mockReturnValue(
+    ref(
+      new DocumentReference(
+        "WebHome",
+        new SpaceReference(undefined, "Home", "Deep Space"),
+      ),
+    ),
+  );
+
+  containerMock.get
+    .calledWith("PageHierarchyResolverProvider")
+    .mockReturnValue(mockHierarchyResolverProvider);
+  containerMock.get
+    .calledWith("ModelReferenceHandlerProvider")
+    .mockReturnValue(mockReferenceHandlerProvider);
+  containerMock.get
+    .calledWith("DocumentService")
+    .mockReturnValue(mockDocumentService);
+
+  mockI18n();
+
+  return mount(NavigationTreeSelect, {
+    props: {
+      label: "Location Label",
+      help: "Location Help",
+      modelValue: options?.location,
+    },
+    global: {
+      provide: {
+        cristal: {
+          getContainer() {
+            return containerMock;
+          },
+        },
+      },
+      stubs: {
+        NavigationTree: NavigationTreeStub,
+        XBreadcrumb: XBreadcrumbStub,
+        XTextField: XTextFieldStub,
+        XDialog: {
+          template: `<div><slot name="activator"></slot><slot></slot><slot name="footer"></slot></div>`,
+        },
+        XBtn: {
+          template: `<button><slot></slot></button>`,
+        },
+      },
+    },
+  });
+}
+
+// The model is a defineModel, so its committed value is observed through the
+// emitted update:modelValue events rather than the (never re-bound) prop.
+function committedLocation(
+  wrapper: ReturnType<typeof mountNavigationTreeSelect>,
+) {
+  const events = wrapper.emitted("update:modelValue");
+  return events ? events[events.length - 1][0] : undefined;
+}
+
+async function clickSelect(
+  wrapper: ReturnType<typeof mountNavigationTreeSelect>,
+) {
+  // The button carries a generated id (useId), so it is located by its label.
+  const selectButton = wrapper
+    .findAll("button")
+    .find(
+      (button) => button.text() === "navigation.tree.select.location.select",
+    )!;
+  await selectButton.trigger("click");
+  await flushPromises();
+}
+
+describe("NavigationTreeSelect", () => {
+  it("displays the location in a readonly design system text field", async () => {
+    const navigationTreeSelect = mountNavigationTreeSelect();
+    await flushPromises();
+
+    // The location is displayed through the design system text field, in
+    // readonly mode since it can only be changed through the tree dialog.
+    const textField = navigationTreeSelect.findComponent(XTextFieldStub);
+    expect(textField.props("readonly")).toBe(true);
+    expect(navigationTreeSelect.text()).toContain("Location Label");
+    expect(navigationTreeSelect.text()).toContain("Location Help");
+  });
+
+  it("displays the hierarchy as non-navigable breadcrumb segments", async () => {
+    const navigationTreeSelect = mountNavigationTreeSelect();
+    await flushPromises();
+
+    const segments = navigationTreeSelect.findAll(".breadcrumb-segment");
+    expect(segments.map((segment) => segment.text())).toEqual([
+      "Home",
+      "Deep Space",
+    ]);
+    // Segments must not link anywhere: navigating would leave the dialog
+    // open on a different page.
+    for (const segment of segments) {
+      expect(segment.attributes("data-url")).toBeUndefined();
+    }
+  });
+
+  it("displays a location provided by the caller instead of the current page space", async () => {
+    const provided = new SpaceReference(undefined, "Provided", "Location");
+    const navigationTreeSelect = mountNavigationTreeSelect({
+      location: provided,
+    });
+    await flushPromises();
+
+    // The hierarchy displayed is the one of the provided location, and the
+    // provided location is not overwritten with the current page space.
+    expect(hierarchyRequests[0]).toStrictEqual(provided);
+    expect(navigationTreeSelect.emitted("update:modelValue")).toBeUndefined();
+  });
+
+  it("only commits the chosen location once Select is clicked", async () => {
+    const navigationTreeSelect = mountNavigationTreeSelect();
+    await flushPromises();
+
+    const chosen = new SpaceReference(undefined, "Sandbox");
+    const tree = navigationTreeSelect.findComponent(NavigationTreeStub);
+
+    // Clicking a node in the tree only stages the choice, it does not update
+    // the model yet.
+    await tree.props("nodeClickAction")({ location: chosen });
+    await flushPromises();
+    expect(committedLocation(navigationTreeSelect)).not.toBe(chosen);
+
+    // The model is updated only when the Select button is clicked.
+    await clickSelect(navigationTreeSelect);
+    expect(committedLocation(navigationTreeSelect)).toStrictEqual(chosen);
+  });
+
+  it("commits the last staged choice when several nodes are clicked", async () => {
+    const navigationTreeSelect = mountNavigationTreeSelect();
+    await flushPromises();
+
+    const tree = navigationTreeSelect.findComponent(NavigationTreeStub);
+    await tree.props("nodeClickAction")({
+      location: new SpaceReference(undefined, "Sandbox"),
+    });
+    const last = new SpaceReference(undefined, "XWiki");
+    await tree.props("nodeClickAction")({ location: last });
+    await flushPromises();
+
+    await clickSelect(navigationTreeSelect);
+    expect(committedLocation(navigationTreeSelect)).toStrictEqual(last);
+  });
+
+  it("does not commit anything when Select is clicked without a choice", async () => {
+    const navigationTreeSelect = mountNavigationTreeSelect();
+    await flushPromises();
+
+    const before = navigationTreeSelect.emitted("update:modelValue")?.length;
+    await clickSelect(navigationTreeSelect);
+    expect(navigationTreeSelect.emitted("update:modelValue")?.length).toBe(
+      before,
+    );
+  });
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2832,21 +2832,36 @@ importers:
       '@types/async-lock':
         specifier: 'catalog:'
         version: 1.4.2
+      '@vue/test-utils':
+        specifier: 'catalog:'
+        version: 2.4.10(@vue/compiler-dom@3.5.38)(@vue/server-renderer@3.5.38(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
       '@xwiki/cristal-dev-config':
         specifier: workspace:*
         version: link:../../../dev/config
+      '@xwiki/cristal-dev-test-utils':
+        specifier: workspace:*
+        version: link:../../../dev/test-utils
       '@xwiki/platform-tool-apiextractorconfig':
         specifier: 'catalog:'
         version: 18.6.0-1782809739
       '@xwiki/platform-tool-tsconfig':
         specifier: 'catalog:'
         version: 18.6.0-1782976222(typescript@5.9.3)
+      inversify:
+        specifier: 'catalog:'
+        version: 8.1.1(reflect-metadata@0.2.2)
       typescript:
         specifier: 'catalog:'
         version: 5.9.3
       vite:
         specifier: 'catalog:'
         version: 7.3.5(@types/node@25.2.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.22.1)(yaml@2.9.0)
+      vitest:
+        specifier: 'catalog:'
+        version: 4.1.6(@types/node@25.2.3)(@vitest/coverage-v8@4.1.6)(happy-dom@20.8.4)(vite@7.3.5(@types/node@25.2.3)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.16))(tsx@4.22.1)(yaml@2.9.0))
+      vitest-mock-extended:
+        specifier: 'catalog:'
+        version: 4.0.0(typescript@5.9.3)(vitest@4.1.6)
       vue:
         specifier: 'catalog:'
         version: 3.5.38(typescript@5.9.3)

--- a/skin/src/vue/__tests__/c-page-creation-menu.test.ts
+++ b/skin/src/vue/__tests__/c-page-creation-menu.test.ts
@@ -1,0 +1,180 @@
+/**
+ * See the LICENSE file distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+import "reflect-metadata";
+import CPageCreationMenu from "../c-page-creation-menu.vue";
+import { flushPromises, mount } from "@vue/test-utils";
+import { mockI18n } from "@xwiki/cristal-dev-test-utils";
+import { DocumentReference, SpaceReference } from "@xwiki/platform-model-api";
+import { describe, expect, it, vi } from "vitest";
+import { mock } from "vitest-mock-extended";
+import { ref } from "vue";
+import type { StorageProvider } from "@xwiki/cristal-backend-api";
+import type { WikiConfig } from "@xwiki/platform-api";
+import type { DocumentService } from "@xwiki/platform-document-api";
+import type {
+  ModelReferenceHandler,
+  ModelReferenceHandlerProvider,
+  ModelReferenceSerializer,
+  ModelReferenceSerializerProvider,
+} from "@xwiki/platform-model-reference-api";
+import type { Container } from "inversify";
+
+vi.mock("vue-i18n");
+
+const NavigationTreeSelectStub = {
+  props: ["modelValue", "label", "help"],
+  template: `<div class="navigation-tree-select-stub"></div>`,
+};
+
+// eslint-disable-next-line max-statements
+function mountPageCreationMenu(options: {
+  currentPageReference: DocumentReference;
+  createDocumentReference: (
+    name: string,
+    space: SpaceReference,
+  ) => DocumentReference;
+}) {
+  const container = mock<Container>();
+
+  const mockDocumentService = mock<DocumentService>({
+    getCurrentDocumentReference() {
+      return ref(options.currentPageReference);
+    },
+  });
+  const mockModelReferenceHandler = mock<ModelReferenceHandler>();
+  mockModelReferenceHandler.createDocumentReference.mockImplementation(
+    options.createDocumentReference,
+  );
+  const mockModelReferenceHandlerProvider =
+    mock<ModelReferenceHandlerProvider>();
+  mockModelReferenceHandlerProvider.get.mockReturnValue(
+    mockModelReferenceHandler,
+  );
+  const mockModelReferenceSerializerProvider =
+    mock<ModelReferenceSerializerProvider>();
+  mockModelReferenceSerializerProvider.get.mockReturnValue(
+    mock<ModelReferenceSerializer>(),
+  );
+  const mockStorageProvider = mock<StorageProvider>();
+
+  container.get
+    .calledWith("DocumentService")
+    .mockReturnValue(mockDocumentService);
+  container.get
+    .calledWith("ModelReferenceHandlerProvider")
+    .mockReturnValue(mockModelReferenceHandlerProvider);
+  container.get
+    .calledWith("ModelReferenceSerializerProvider")
+    .mockReturnValue(mockModelReferenceSerializerProvider);
+  container.get
+    .calledWith("StorageProvider")
+    .mockReturnValue(mockStorageProvider);
+
+  mockI18n();
+
+  return mount(CPageCreationMenu, {
+    props: {
+      currentPageReference: options.currentPageReference,
+    },
+    global: {
+      provide: {
+        cristal: {
+          getContainer() {
+            return container;
+          },
+          getWikiConfig() {
+            return mock<WikiConfig>({
+              getNewPageDefaultName() {
+                return "NewPage";
+              },
+            });
+          },
+        },
+      },
+      stubs: {
+        NavigationTreeSelect: NavigationTreeSelectStub,
+        CIcon: true,
+        XDialog: {
+          template: `<div><slot name="activator" :activatorProps="{}"></slot><slot></slot><slot name="footer"></slot></div>`,
+        },
+        XBtn: {
+          template: `<button><slot></slot></button>`,
+        },
+        XForm: {
+          template: `<form><slot></slot></form>`,
+        },
+        XTextField: {
+          template: `<div></div>`,
+        },
+        XAlert: {
+          template: `<div><slot></slot></div>`,
+        },
+      },
+    },
+  });
+}
+
+async function openDialog(wrapper: ReturnType<typeof mountPageCreationMenu>) {
+  await wrapper.find("#new-page-button").trigger("click");
+  await flushPromises();
+}
+
+describe("c-page-creation-menu", () => {
+  it("opens with the current page as parent location (path-based backend)", async () => {
+    // Path-based backends (e.g. Nextcloud): the document name is a plain
+    // path segment, re-creating a document from its own name and space
+    // yields the same document.
+    const menu = mountPageCreationMenu({
+      currentPageReference: new DocumentReference(
+        "subpage",
+        new SpaceReference(undefined, "home"),
+      ),
+      createDocumentReference: (name, space) =>
+        new DocumentReference(name, space),
+    });
+    await openDialog(menu);
+
+    expect(
+      menu.findComponent(NavigationTreeSelectStub).props("modelValue"),
+    ).toStrictEqual(new SpaceReference(undefined, "home", "subpage"));
+  });
+
+  it("opens with the current page as parent location (XWiki-style backend)", async () => {
+    // XWiki-style backends: the document name is a marker ("WebHome"), the
+    // space of the document already designates the page.
+    const menu = mountPageCreationMenu({
+      currentPageReference: new DocumentReference(
+        "WebHome",
+        new SpaceReference(undefined, "Space", "Page"),
+      ),
+      createDocumentReference: (name, space) =>
+        new DocumentReference(
+          "WebHome",
+          new SpaceReference(space.wiki, ...space.names, name),
+        ),
+    });
+    await openDialog(menu);
+
+    expect(
+      menu.findComponent(NavigationTreeSelectStub).props("modelValue"),
+    ).toStrictEqual(new SpaceReference(undefined, "Space", "Page"));
+  });
+});

--- a/skin/src/vue/__tests__/c-sidebar.test.ts
+++ b/skin/src/vue/__tests__/c-sidebar.test.ts
@@ -59,6 +59,9 @@ function mountCComponent() {
   const mockModelReferenceHandlerProvider =
     mock<ModelReferenceHandlerProvider>();
   const mockModelReferenceHandler = mock<ModelReferenceHandler>();
+  mockModelReferenceHandler.createDocumentReference.mockImplementation(
+    (name, space) => new DocumentReference(name, space),
+  );
   mockModelReferenceHandlerProvider.get.mockReturnValue(
     mockModelReferenceHandler,
   );

--- a/skin/src/vue/c-page-creation-menu.vue
+++ b/skin/src/vue/c-page-creation-menu.vue
@@ -58,7 +58,7 @@ const canCreate: Ref<boolean> = ref(true);
 let newDocumentReferenceString: string = "";
 let parentDocumentReferenceString: string = "";
 
-defineProps<{
+const props = defineProps<{
   currentPageReference?: DocumentReference;
 }>();
 
@@ -71,6 +71,32 @@ function updateCurrentPage() {
   name.value = "";
   existingPage.value = undefined;
   canCreate.value = true;
+  location.value = currentPageLocation();
+}
+
+/**
+ * The location of the current page, seen as the container of the new page.
+ */
+function currentPageLocation(): SpaceReference | undefined {
+  const document =
+    props.currentPageReference ??
+    documentService.getCurrentDocumentReference().value;
+  if (!document) {
+    return undefined;
+  }
+  const space = document.space ?? new SpaceReference();
+  const probe = referenceHandler.createDocumentReference(document.name, space);
+  if (
+    probe.name === document.name &&
+    (probe.space?.names ?? []).join("/") === space.names.join("/")
+  ) {
+    // The document name is a plain path segment (path-based backends like
+    // Nextcloud): the location of the page includes its name.
+    return new SpaceReference(space.wiki, ...space.names, document.name);
+  }
+  // The backend uses a marker document name (e.g. WebHome): the space of the
+  // document already designates the page.
+  return space;
 }
 
 // eslint-disable-next-line max-statements
@@ -251,7 +277,11 @@ async function editExistingPage() {
   cursor: pointer;
 }
 #new-page-content {
-  min-width: 600px;
+  /* Aim for a comfortable 600px width, but never overflow a dialog that is
+     narrower than that (e.g. the fixed-width Nextcloud dialog), which would
+     otherwise show a horizontal scrollbar. */
+  width: 600px;
+  max-width: 100%;
 }
 
 .grid {


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTALNC-36

# Changes

## Description

* The breadcrumb displaying the parent location in the new page (and move page) dialog was made of real links: clicking a segment navigated to that location while leaving the dialog open. The urls are now stripped from the breadcrumb items so the segments are not rendered as links (`url` is already optional in `BreadcrumbProps`). The location display keeps using the abstract `x-text-field` design system component (readonly, breadcrumb in the default slot), as before.
* Choosing a location in the "Change Page Location" dialog now only stages the choice; it is applied to the field once the user confirms with the Select button (and discarded if the dialog is closed without confirming), instead of being applied immediately on the tree node click.
* The new page dialog content used a hard `min-width: 600px`, which overflowed with a horizontal scrollbar in a dialog narrower than 600px (e.g. the fixed-width Nextcloud dialog). It now targets 600px but caps at `max-width: 100%`, so it keeps the intended width in the auto-sizing Vuetify dialog while fitting a narrower dialog without overflow.
* The new page dialog now opens with the parent location set to the current page, refreshed on each opening. Previously the location was computed once when the menu mounted (so it went stale after navigating), and was set to the *space* of the current document — which for path-based backends (e.g. Nextcloud, where the document name is a plain path segment) designated the parent of the current page (or even the root for top-level pages) instead of the page itself. `NavigationTreeSelect` now honors a location provided by its caller instead of always overwriting it with the current page space (`MovePage` keeps the previous default, which is correct for moving).

## Clarifications

* This PR addresses the behavioral problems of CRISTALNC-36 (breadcrumb navigation with the dialog open, horizontal overflow, plus the selection and default-location improvements). The purely cosmetic points of the report (input affordances on the readonly field, cropping of long locations, hover background overlapping the label in the Nextcloud design system) come from how each design system implementation of `x-text-field` renders a readonly field and places its default slot (Vuetify: field content, Shoelace: prefix, Nextcloud: icon slot); addressing them belongs in the design system implementations, not in this component.
* No design-system API change.
* The Nextcloud app will pick the fixes up with its next dependency bump.

# Screenshots & Video

The issue contains a video of the previous behavior. After the change, the location field looks as before (readonly design system text field with the breadcrumb inside), but its segments are not clickable, the location shown is the current page and only changes when Select is pressed, and the dialog no longer shows a horizontal scrollbar in the Nextcloud design system.

# Executed Tests

* `pnpm --filter ./core/navigation-tree/navigation-tree-ui test` (6 unit tests for `NavigationTreeSelect`: readonly field display, breadcrumb segments without urls, caller-provided location honored, location committed only on Select, last staged choice committed, nothing committed when Select is pressed without a choice), plus `lint`, `typecheck`, `build` and `api-extractor:local` on the same package.
* `pnpm --filter ./skin test` — new `c-page-creation-menu` tests checking the dialog opens with the current page as parent location for both path-based and XWiki-style (`WebHome`) backends, plus the pre-existing skin tests.
* Manually verified with `pnpm run dev:cristal-web` against the XWiki demo backend (Playwright-driven): opened the new page dialog, changed the location through "Change Page Location", checked that the breadcrumb updates, has no links, and that clicking a segment neither navigates nor closes the dialog. Confirmed the dialog content stays 600px wide in the Vuetify design system, and that after navigating in-app from the home page to another page, reopening the dialog shows the newly current page as parent location.
* The horizontal-scrollbar fix was reproduced and validated against the actual Nextcloud design system (`NcDialog`, `@nextcloud/vue`) in a standalone harness: the `min-width: 600px` content overflowed the ~388px fixed dialog before the change and fits without overflow after.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches: none

