### PR TITLE
CRISTAL-843: Editing a link in the BlockNote editor fails on a missing ResourceReferenceParser component

### DIFF
--- a/editors/blocknote/package.json
+++ b/editors/blocknote/package.json
@@ -46,6 +46,7 @@
     "@xwiki/platform-model-api": "catalog:",
     "@xwiki/platform-model-reference-api": "catalog:",
     "@xwiki/platform-model-remote-url-api": "catalog:",
+    "@xwiki/platform-rendering-api": "catalog:",
     "@xwiki/platform-syntaxes-config": "catalog:",
     "@xwiki/platform-uniast-api": "catalog:",
     "@xwiki/platform-uniast-markdown": "catalog:",

--- a/editors/blocknote/src/components/componentsInit.ts
+++ b/editors/blocknote/src/components/componentsInit.ts
@@ -19,6 +19,7 @@
  */
 
 import { UixBlocknoteEditorProvider } from "./uixBlocknoteEditorProvider";
+import { DefaultResourceReferenceParser } from "@xwiki/platform-rendering-api";
 import { Container } from "inversify";
 import type { UIXTemplateProvider } from "@xwiki/cristal-skin";
 
@@ -31,5 +32,8 @@ export default class ComponentInit {
       .bind<UIXTemplateProvider>("UIXTemplateProvider")
       .to(UixBlocknoteEditorProvider)
       .whenNamed(UixBlocknoteEditorProvider.extensionPoint);
+    // The editor hands this container to the BlockNote link edition components,
+    // which resolve a ResourceReferenceParser from it.
+    DefaultResourceReferenceParser.bind(container);
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -153,6 +153,9 @@ catalogs:
     '@xwiki/platform-navigation-tree-api':
       specifier: 18.6.0
       version: 18.6.0
+    '@xwiki/platform-rendering-api':
+      specifier: 18.6.0
+      version: 18.6.0
     '@xwiki/platform-syntaxes-config':
       specifier: 18.6.0
       version: 18.6.0
@@ -4090,6 +4093,9 @@ importers:
       '@xwiki/platform-model-remote-url-api':
         specifier: 'catalog:'
         version: 18.6.0(inversify@8.1.1(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)(vue-router@5.0.3(@vue/compiler-sfc@3.5.40)(vue@3.5.38(typescript@5.9.3)))(vue@3.5.38(typescript@5.9.3))
+      '@xwiki/platform-rendering-api':
+        specifier: 'catalog:'
+        version: 18.6.0(inversify@8.1.1(reflect-metadata@0.2.2))(reflect-metadata@0.2.2)
       '@xwiki/platform-syntaxes-config':
         specifier: 'catalog:'
         version: 18.6.0(@types/node@26.1.1)(jiti@2.7.0)(sugarss@5.0.1(postcss@8.5.22))(tsx@4.22.1)(yaml@2.9.0)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -126,6 +126,7 @@ catalog:
   '@xwiki/platform-model-reference-api': 18.6.0
   '@xwiki/platform-model-remote-url-api': 18.6.0
   '@xwiki/platform-navigation-tree-api': 18.6.0
+  '@xwiki/platform-rendering-api': 18.6.0
   '@xwiki/platform-syntaxes-config': 18.6.0
   '@xwiki/platform-tool-apiextractorconfig': 18.6.0
   '@xwiki/platform-tool-tsconfig': 18.6.0


### PR DESCRIPTION
# Jira URL

https://jira.xwiki.org/browse/CRISTAL-843

# Changes

## Description

* Bind `DefaultResourceReferenceParser` in the BlockNote editor's `ComponentInit`, so that the
  container the editor hands to the BlockNote link edition components can resolve the
  `ResourceReferenceParser` they require. Without it, clicking "Create link" in the formatting
  toolbar (or editing an existing link) throws `No bindings found for service:
  "ResourceReferenceParser"` and no link edition field opens.
* Declare `@xwiki/platform-rendering-api` as a dependency of `@xwiki/cristal-editors-blocknote`
  (catalog entry `18.6.0`), since it now imports from it.

## Clarifications

* `ResourceReferenceParser` is new in XWiki Platform 18.6.0, which Cristal adopted in 1.6.0 — hence
  the regression in that release. The component is never registered automatically: platform only
  exposes the static `DefaultResourceReferenceParser.bind(container)` helper, and nothing in Cristal
  nor in the platform packages calls it.
* The binding belongs to the editor's `ComponentInit` rather than to `defaultComponentsList`, because
  the editor is the only consumer, and because that `ComponentInit` is the single place every
  embedding application goes through — `conditionalComponentsList` for the Cristal apps, and an
  explicit `new BlocknoteEditorComponentInit(container)` for the Nextcloud integration.
* All applications embedding the BlockNote editor are affected (web, Electron, Nextcloud
  integration), which is why the fix is here and not in each application.
* `pnpm-lock.yaml` is edited down to the two entries the new dependency needs. A plain
  `pnpm install` additionally rewrites ~380 lines of unrelated eslint peer suffixes
  (`(supports-color@5.5.0)`), which does not belong in a maintenance-branch fix.
  `pnpm install --frozen-lockfile` passes on the lockfile as committed.
* On `main` the editor's dependencies move to the explicit `EditorDeps` object of platform 18.7
  (`resourceReferenceParser` becomes a value the application resolves and passes), so this fix is
  deliberately limited to `stable-1.6.x`.

# Screenshots & Video

Before — clicking "Create link" opens nothing, and the console shows:

```
Uncaught Error: No bindings found for service: "ResourceReferenceParser".

Trying to resolve bindings for "ResourceReferenceParser (Root service)".

Binding constraints:
- service identifier: ResourceReferenceParser
- name: -
```

After — the link edition field ("Query or URL…") opens as expected, with no error.

# Executed Tests

* `nx run-many -t typecheck lint test build -p @xwiki/cristal-editors-blocknote` — all green.
* `pnpm install --frozen-lockfile` — accepts the committed lockfile.
* End to end in a running instance of the Nextcloud integration (a Cristal application embedding the
  BlockNote editor), on Nextcloud 34: reproduced the failure with 1.6.0, then ran the same scenario
  against this branch's build of `@xwiki/cristal-editors-blocknote`:
  * selecting text and clicking "Create link" opens the link edition field, with no page error
    (before: uncaught error, no field);
  * typing a page name lists the matching link suggestion;
  * validating creates the link, resolved to
    `http://localhost:8081/remote.php/dav/files/admin/.cristal/home.md` — so the reference goes
    through `ResourceReferenceParser.parse()` and out to a valid Nextcloud remote URL, rather than the
    binding merely being present.

# Expected merging strategy

* Prefers squash: Yes
* Backport on branches:
  * N/A — this targets `stable-1.6.x` directly, for the 1.6.1 release.

Generated with [Claude Code](https://claude.com/claude-code)
